### PR TITLE
Fix/DNS loadbalancing - templates

### DIFF
--- a/templates/terraformer/aws/dns/dns_alternative_names.tpl
+++ b/templates/terraformer/aws/dns/dns_alternative_names.tpl
@@ -1,3 +1,4 @@
+{{- $hostname          := .Data.Hostname }}
 {{- $specName          := .Data.Provider.SpecName }}
 {{- $uniqueFingerPrint := .Fingerprint }}
 {{- $resourceSuffix    := printf "%s_%s" $specName $uniqueFingerPrint }}
@@ -5,19 +6,16 @@
 
 {{- if hasExtension .Data "AlternativeNamesExtension" }}
 	{{- range $_, $alternativeName := .Data.AlternativeNamesExtension.Names }}
+    resource "aws_route53_record" "record_{{ $alternativeName }}_{{ $resourceSuffix }}" {
+      provider    = aws.dns_aws_{{ $resourceSuffix }}
+      zone_id     = "${data.aws_route53_zone.aws_zone_{{ $resourceSuffix }}.zone_id }"
+      name        = "{{ $alternativeName }}"
+      type        = "CNAME"
+      ttl         = 300
+      records     = ["{{ $hostname }}.${data.aws_route53_zone.aws_zone_{{ $resourceSuffix }}.name}"]
 
-	resource "aws_route53_record" "record_{{ $alternativeName }}_{{ $resourceSuffix }}" {
-        provider    = aws.dns_aws_{{ $resourceSuffix }}
-        zone_id     = "${data.aws_route53_zone.aws_zone_{{ $resourceSuffix }}.zone_id }"
-        name        = "{{ $alternativeName }}.${data.aws_route53_zone.aws_zone_{{ $resourceSuffix }}.name}"
-        type        = "A"
-        ttl         = 300
-        records     = [
-        {{- range $ip := $.Data.RecordData.IP }}
-            "{{ $ip.V4 }}",
-        {{- end }}
-        ]
-	}
+      set_identifier = "record_{{ $alternativeName }}_{{ $resourceSuffix }}"
+    }
 
 	output "{{ $clusterID }}_{{ $alternativeName }}_{{ $resourceSuffix }}" {
 	  value = { "{{ $clusterID }}-{{ $alternativeName }}-endpoint" = aws_route53_record.record_{{ $alternativeName }}_{{ $resourceSuffix }}.name }

--- a/templates/terraformer/aws/dns/dns_alternative_names.tpl
+++ b/templates/terraformer/aws/dns/dns_alternative_names.tpl
@@ -15,6 +15,9 @@
       records     = ["{{ $hostname }}.${data.aws_route53_zone.aws_zone_{{ $resourceSuffix }}.name}"]
 
       set_identifier = "record_{{ $alternativeName }}_{{ $resourceSuffix }}"
+      weighted_routing_policy {
+        weight = 1
+      }
     }
 
 	output "{{ $clusterID }}_{{ $alternativeName }}_{{ $resourceSuffix }}" {

--- a/templates/terraformer/azure/dns/dns.tpl
+++ b/templates/terraformer/azure/dns/dns.tpl
@@ -1,3 +1,4 @@
+{{- $hostname          := .Data.Hostname }}
 {{- $specName          := .Data.Provider.SpecName }}
 {{- $uniqueFingerPrint := .Fingerprint }}
 {{- $resourceSuffix    := printf "%s_%s" $specName $uniqueFingerPrint }}
@@ -13,23 +14,47 @@ provider "azurerm" {
 }
 
 data "azurerm_dns_zone" "azure_zone_{{ $resourceSuffix }}" {
-    provider = azurerm.dns_azure_{{ $resourceSuffix }}
-    name     = "{{ .Data.DNSZone }}"
+  provider = azurerm.dns_azure_{{ $resourceSuffix }}
+  name     = "{{ .Data.DNSZone }}"
 }
 
-resource "azurerm_dns_a_record" "record_{{ $resourceSuffix }}" {
+resource "azurerm_traffic_manager_profile" "traffic_manager_{{ $hostname }}_{{ $resourceSuffix}}" {
   provider            = azurerm.dns_azure_{{ $resourceSuffix }}
-  name                = "{{ .Data.Hostname }}"
+  name                = "traffic-manager-{{ $hostname }}"
+  resource_group_name = data.azurerm_dns_zone.azure_zone_{{ $resourceSuffix }}.resource_group_name
+
+  traffic_routing_method = "Weighted"
+
+  dns_config {
+    relative_name = "{{ $hostname }}"
+    ttl           = 30
+  }
+
+  monitor_config {
+    protocol = "TCP"
+    port     = 6443
+  }
+}
+
+{{- range $index, $ip := .Data.RecordData.IP }}
+  resource "azurerm_traffic_manager_external_endpoint" "endpoint_{{ $hostname }}_{{ $index }}_{{ $resourceSuffix}}" {
+    provider             = azurerm.dns_azure_{{ $resourceSuffix }}
+    name                 = "{{ $hostname }}_{{ $index }}_{{ $resourceSuffix}}"
+    profile_id           = azurerm_traffic_manager_profile.traffic_manager_{{ $hostname }}_{{ $resourceSuffix}}.id
+    weight               = 1
+    target               = "{{ $ip.V4 }}"
+  }
+{{- end }}
+
+resource "azurerm_dns_cname_record" "record_{{ $hostname }}_{{ $resourceSuffix }}" {
+  provider            = azurerm.dns_azure_{{ $resourceSuffix }}
+  name                = "{{ $hostname }}"
   zone_name           = data.azurerm_dns_zone.azure_zone_{{ $resourceSuffix }}.name
   resource_group_name = data.azurerm_dns_zone.azure_zone_{{ $resourceSuffix }}.resource_group_name
   ttl                 = 300
-  records             = [
-  {{- range $ip := .Data.RecordData.IP }}
-  "{{ $ip.V4 }}",
-  {{- end }}
-  ]
+  record              = azurerm_traffic_manager_profile.traffic_manager_{{ $hostname }}_{{ $resourceSuffix}}.fqdn
 }
 
 output "{{ $clusterID }}_{{ $resourceSuffix }}" {
-    value = { "{{ $clusterID }}-endpoint" = format("%s.%s", azurerm_dns_a_record.record_{{ $resourceSuffix }}.name, azurerm_dns_a_record.record_{{ $resourceSuffix }}.zone_name)}
+  value = { "{{ $clusterID }}-endpoint" = format("%s.%s", azurerm_dns_cname_record.record_{{ $hostname }}_{{ $resourceSuffix }}.name, azurerm_dns_cname_record.record_{{ $hostname }}_{{ $resourceSuffix }}.zone_name)}
 }

--- a/templates/terraformer/azure/dns/dns.tpl
+++ b/templates/terraformer/azure/dns/dns.tpl
@@ -36,10 +36,11 @@ resource "azurerm_traffic_manager_profile" "traffic_manager_{{ $hostname }}_{{ $
   }
 }
 
-{{- range $index, $ip := .Data.RecordData.IP }}
-  resource "azurerm_traffic_manager_external_endpoint" "endpoint_{{ $hostname }}_{{ $index }}_{{ $resourceSuffix}}" {
+{{- range $_, $ip := .Data.RecordData.IP }}
+  {{- $escapedIPv4 := replaceAll $ip.V4 "." "_" }}
+  resource "azurerm_traffic_manager_external_endpoint" "endpoint_{{ $hostname }}_{{ $escapedIPv4 }}_{{ $resourceSuffix}}" {
     provider             = azurerm.dns_azure_{{ $resourceSuffix }}
-    name                 = "{{ $hostname }}_{{ $index }}_{{ $resourceSuffix}}"
+    name                 = "{{ $hostname }}_{{ $escapedIPv4 }}_{{ $resourceSuffix}}"
     profile_id           = azurerm_traffic_manager_profile.traffic_manager_{{ $hostname }}_{{ $resourceSuffix}}.id
     weight               = 1
     target               = "{{ $ip.V4 }}"

--- a/templates/terraformer/azure/dns/dns_alternative_names.tpl
+++ b/templates/terraformer/azure/dns/dns_alternative_names.tpl
@@ -1,26 +1,24 @@
+{{- $hostname          := .Data.Hostname }}
 {{- $specName          := .Data.Provider.SpecName }}
 {{- $uniqueFingerPrint := .Fingerprint }}
 {{- $resourceSuffix    := printf "%s_%s" $specName $uniqueFingerPrint }}
 {{- $clusterID 	       := printf "%s-%s" .Data.ClusterName .Data.ClusterHash }}
 
+### Alternative Name must be as CNAME pointing to azure traffic manager profile
 {{- if hasExtension .Data "AlternativeNamesExtension" }}
 	{{- range $_, $alternativeName := .Data.AlternativeNamesExtension.Names }}
 
-	resource "azurerm_dns_a_record" "record_{{ $alternativeName }}_{{ $resourceSuffix }}" {
-	   provider            = azurerm.dns_azure_{{ $resourceSuffix }}
-	   name                = "{{ $alternativeName }}"
-	   zone_name           = data.azurerm_dns_zone.azure_zone_{{ $resourceSuffix }}.name
-	   resource_group_name = data.azurerm_dns_zone.azure_zone_{{ $resourceSuffix }}.resource_group_name
-	   ttl                 = 300
-	   records             = [
-	       {{- range $ip := $.Data.RecordData.IP }}
-		      "{{ $ip.V4 }}",
-		   {{- end }}
-	   ]
+	resource "azurerm_dns_cname_record" "record_{{ $alternativeName }}_{{ $resourceSuffix }}" {
+		provider            = azurerm.dns_azure_{{ $resourceSuffix }}
+		name                = "{{ $alternativeName }}"
+		zone_name           = data.azurerm_dns_zone.azure_zone_{{ $resourceSuffix }}.name
+		resource_group_name = data.azurerm_dns_zone.azure_zone_{{ $resourceSuffix }}.resource_group_name
+		ttl                 = 300
+		record              = azurerm_traffic_manager_profile.traffic_manager_{{ $hostname }}_{{ $resourceSuffix }}.fqdn
 	}
 
 	output "{{ $clusterID }}_{{ $alternativeName }}_{{ $resourceSuffix }}" {
-	  value = { "{{ $clusterID }}-{{ $alternativeName }}-endpoint" = format("%s.%s", azurerm_dns_a_record.record_{{ $alternativeName }}_{{ $resourceSuffix }}.name, azurerm_dns_a_record.record_{{ $alternativeName }}_{{ $resourceSuffix}}.zone_name )}
+		value = { "{{ $clusterID }}-{{ $alternativeName }}-endpoint" = format("%s.%s", azurerm_dns_cname_record.record_{{ $alternativeName }}_{{ $resourceSuffix }}.name, azurerm_dns_cname_record.record_{{ $alternativeName }}_{{ $resourceSuffix }}.zone_name)}
 	}
 
 	{{- end }}

--- a/templates/terraformer/cloudflare/dns/dns.tpl
+++ b/templates/terraformer/cloudflare/dns/dns.tpl
@@ -13,8 +13,56 @@ data "cloudflare_zone" "cloudflare_zone_{{ $resourceSuffix }}" {
   name       = "{{ .Data.DNSZone }}"
 }
 
-{{- range $ip := .Data.RecordData.IP }}
+### If subscription has paid addon Cloudflare Load Balancing,
+### implement load balancer with health check, otherwise
+### create A records without load balancer and health check
+{{- and (hasExtension .Data "ProviderExtrasExtension") (.Data.ProviderExtrasExtension.SubscriptionAllowsHA) }}
+  resource "cloudflare_load_balancer_pool" "lb_pool_{{ $resourceSuffix }}" {
+    provider    = cloudflare.cloudflare_dns_{{ $resourceSuffix }}
+    account_id  = "{{ .Data.Provider.GetCloudflare.GetAccountID }}"
+    name        = "pool-{{ $resourceSuffix }}"
 
+    {{- range $index, $ip := .Data.RecordData.IP }}
+      origins {
+        name    = "origin-{{ $index }}"
+        address = "{{ $ip.V4 }}"
+        weight  = 1
+      }
+    {{- end }}
+      
+      monitor = cloudflare_load_balancer_monitor.monitor_{{ $resourceSuffix }}.id
+  }
+
+  resource "cloudflare_load_balancer_monitor" "monitor_{{ $resourceSuffix }}" {
+    provider    = cloudflare.cloudflare_dns_{{ $resourceSuffix }}
+    account_id  = "{{ .Data.Provider.GetCloudflare.GetAccountID }}"
+    type        = "tcp"
+    port        = 6443
+    timeout     = 5
+    retries     = 2
+    interval    = 60
+  }
+
+  resource "cloudflare_load_balancer" "load_balancer_{{ $resourceSuffix }}" {
+    provider          = cloudflare.cloudflare_dns_{{ $resourceSuffix }}
+    zone_id           = data.cloudflare_zone.cloudflare_zone_{{ $resourceSuffix }}.id
+    name              = "{{ $.Data.Hostname }}.{{ .Data.DNSZone }}"
+    fallback_pool_id  = cloudflare_load_balancer_pool.lb_pool_{{ $resourceSuffix }}.id
+
+    default_pool_ids = [
+      cloudflare_load_balancer_pool.lb_pool_{{ $resourceSuffix }}.id,
+    ]
+    ttl     = 30
+
+    steering_policy="random"
+  }
+  output "{{ $clusterID }}_{{ $resourceSuffix }}" {
+    value = { "{{ $clusterID }}-endpoint" = format("%s.%s", "{{ .Data.Hostname }}", "{{ .Data.DNSZone }}")}
+  }
+### If subscription does not include claudflare paid addon
+### for DNS balancing, create DNS A records with no health check
+{{- else }}
+  {{- range $ip := .Data.RecordData.IP }}
     {{- $escapedIPv4 := replaceAll $ip.V4 "." "_"}}
     {{- $recordResourceName := printf "record_%s_%s" $escapedIPv4 $resourceSuffix }}
 
@@ -26,9 +74,9 @@ data "cloudflare_zone" "cloudflare_zone_{{ $resourceSuffix }}" {
       type     = "A"
       ttl      = 300
     }
-
+  {{- end }} 
+  output "{{ $clusterID }}_{{ $resourceSuffix }}" {
+    value = { "{{ $clusterID }}-endpoint" = format("%s.%s", "{{ .Data.Hostname }}", "{{ .Data.DNSZone }}")}
+  }
+  {{- end }}
 {{- end }}
-
-output "{{ $clusterID }}_{{ $resourceSuffix }}" {
-  value = { "{{ $clusterID }}-endpoint" = format("%s.%s", "{{ .Data.Hostname }}", "{{ .Data.DNSZone }}")}
-}

--- a/templates/terraformer/cloudflare/dns/dns.tpl
+++ b/templates/terraformer/cloudflare/dns/dns.tpl
@@ -22,7 +22,7 @@ data "cloudflare_zone" "cloudflare_zone_{{ $resourceSuffix }}" {
     account_id  = "{{ .Data.Provider.GetCloudflare.GetAccountID }}"
     name        = "pool-{{ $resourceSuffix }}"
 
-    {{- range $index, $ip := .Data.RecordData.IP }}
+    {{- range $_, $ip := .Data.RecordData.IP }}
       {{- $escapedIPv4 := replaceAll $ip.V4 "." "_" }}
       origins {
         name    = "origin-{{ $escapedIPv4 }}"

--- a/templates/terraformer/cloudflare/dns/dns.tpl
+++ b/templates/terraformer/cloudflare/dns/dns.tpl
@@ -79,5 +79,4 @@ data "cloudflare_zone" "cloudflare_zone_{{ $resourceSuffix }}" {
   output "{{ $clusterID }}_{{ $resourceSuffix }}" {
     value = { "{{ $clusterID }}-endpoint" = format("%s.%s", "{{ .Data.Hostname }}", "{{ .Data.DNSZone }}")}
   }
-  {{- end }}
 {{- end }}

--- a/templates/terraformer/cloudflare/dns/dns.tpl
+++ b/templates/terraformer/cloudflare/dns/dns.tpl
@@ -16,7 +16,8 @@ data "cloudflare_zone" "cloudflare_zone_{{ $resourceSuffix }}" {
 ### If subscription has paid addon Cloudflare Load Balancing,
 ### implement load balancer with health check, otherwise
 ### create A records without load balancer and health check
-{{- and (hasExtension .Data "ProviderExtrasExtension") (.Data.ProviderExtrasExtension.SubscriptionAllowsHA) }}
+{{- if hasExtension .Data "ProviderExtrasExtension" }}
+  {{- if .Data.ProviderExtrasExtension.SubscriptionAllowsHA }}
   resource "cloudflare_load_balancer_pool" "lb_pool_{{ $resourceSuffix }}" {
     provider    = cloudflare.cloudflare_dns_{{ $resourceSuffix }}
     account_id  = "{{ .Data.Provider.GetCloudflare.GetAccountID }}"
@@ -61,7 +62,7 @@ data "cloudflare_zone" "cloudflare_zone_{{ $resourceSuffix }}" {
   }
 ### If subscription does not include claudflare paid addon
 ### for DNS balancing, create DNS A records with no health check
-{{- else }}
+  {{- else }}
   {{- range $ip := .Data.RecordData.IP }}
     {{- $escapedIPv4 := replaceAll $ip.V4 "." "_"}}
     {{- $recordResourceName := printf "record_%s_%s" $escapedIPv4 $resourceSuffix }}

--- a/templates/terraformer/cloudflare/dns/dns.tpl
+++ b/templates/terraformer/cloudflare/dns/dns.tpl
@@ -16,16 +16,16 @@ data "cloudflare_zone" "cloudflare_zone_{{ $resourceSuffix }}" {
 ### If subscription has paid addon Cloudflare Load Balancing,
 ### implement load balancer with health check, otherwise
 ### create A records without load balancer and health check
-{{- if hasExtension .Data "ProviderExtrasExtension" }}
-  {{- if $.Data.ProviderExtrasExtension.SubscriptionAllowsHA }}
+{{- if and (hasExtension .Data "ProviderExtrasExtension") (.Data.ProviderExtrasExtension.SubscriptionAllowsHA ) }}
   resource "cloudflare_load_balancer_pool" "lb_pool_{{ $resourceSuffix }}" {
     provider    = cloudflare.cloudflare_dns_{{ $resourceSuffix }}
     account_id  = "{{ .Data.Provider.GetCloudflare.GetAccountID }}"
     name        = "pool-{{ $resourceSuffix }}"
 
     {{- range $index, $ip := .Data.RecordData.IP }}
+      {{- $escapedIPv4 := replaceAll $ip.V4 "." "_" }}
       origins {
-        name    = "origin-{{ $index }}"
+        name    = "origin-{{ $escapedIPv4 }}"
         address = "{{ $ip.V4 }}"
         weight  = 1
       }
@@ -62,7 +62,7 @@ data "cloudflare_zone" "cloudflare_zone_{{ $resourceSuffix }}" {
   }
 ### If subscription does not include claudflare paid addon
 ### for DNS balancing, create DNS A records with no health check
-  {{- else }}
+{{- else }}
   {{- range $ip := .Data.RecordData.IP }}
     {{- $escapedIPv4 := replaceAll $ip.V4 "." "_"}}
     {{- $recordResourceName := printf "record_%s_%s" $escapedIPv4 $resourceSuffix }}

--- a/templates/terraformer/cloudflare/dns/dns.tpl
+++ b/templates/terraformer/cloudflare/dns/dns.tpl
@@ -17,7 +17,7 @@ data "cloudflare_zone" "cloudflare_zone_{{ $resourceSuffix }}" {
 ### implement load balancer with health check, otherwise
 ### create A records without load balancer and health check
 {{- if hasExtension .Data "ProviderExtrasExtension" }}
-  {{- if .Data.ProviderExtrasExtension.SubscriptionAllowsHA }}
+  {{- if $.Data.ProviderExtrasExtension.SubscriptionAllowsHA }}
   resource "cloudflare_load_balancer_pool" "lb_pool_{{ $resourceSuffix }}" {
     provider    = cloudflare.cloudflare_dns_{{ $resourceSuffix }}
     account_id  = "{{ .Data.Provider.GetCloudflare.GetAccountID }}"

--- a/templates/terraformer/cloudflare/dns/dns_alternative_names.tpl
+++ b/templates/terraformer/cloudflare/dns/dns_alternative_names.tpl
@@ -5,7 +5,6 @@
 
 {{- if hasExtension .Data "AlternativeNamesExtension" }}
 	{{- range $_, $alternativeName := .Data.AlternativeNamesExtension.Names }}
-
     {{- $recordResourceName := printf "record_%s_%s" $alternativeName $resourceSuffix }}
 
     resource "cloudflare_record" "{{ $recordResourceName }}" {
@@ -20,6 +19,5 @@
 	output "{{ $clusterID }}_{{ $alternativeName }}_{{ $resourceSuffix }}" {
 	  value = { "{{ $clusterID }}-{{ $alternativeName }}-endpoint" = format("%s.%s", "{{ $alternativeName }}", "{{ $.Data.DNSZone }}")}
 	}
-
 	{{- end }}
 {{- end }}

--- a/templates/terraformer/cloudflare/dns/dns_alternative_names.tpl
+++ b/templates/terraformer/cloudflare/dns/dns_alternative_names.tpl
@@ -14,8 +14,8 @@
                 provider = cloudflare.cloudflare_dns_{{ $resourceSuffix }}
                 zone_id = data.cloudflare_zone.cloudflare_zone_{{ $resourceSuffix }}.id
                 name = "{{ $alternativeName }}"
-                value = "{{ $ip.V4 }}"
-                type = "A"
+                value = "{{ $.Data.Hostname }}.{{ .Data.DNSZone }}"
+                type = "CNAME"
                 ttl = 300
             }
         {{- end }}

--- a/templates/terraformer/cloudflare/dns/dns_alternative_names.tpl
+++ b/templates/terraformer/cloudflare/dns/dns_alternative_names.tpl
@@ -6,19 +6,16 @@
 {{- if hasExtension .Data "AlternativeNamesExtension" }}
 	{{- range $_, $alternativeName := .Data.AlternativeNamesExtension.Names }}
 
-        {{- range $ip := $.Data.RecordData.IP }}
-            {{- $escapedIPv4 := replaceAll $ip.V4 "." "_" }}
-            {{- $recordResourceName := printf "record_%s_%s_%s" $alternativeName $escapedIPv4 $resourceSuffix }}
+    {{- $recordResourceName := printf "record_%s_%s" $alternativeName $resourceSuffix }}
 
-            resource "cloudflare_record" "{{ $recordResourceName }}" {
-                provider = cloudflare.cloudflare_dns_{{ $resourceSuffix }}
-                zone_id = data.cloudflare_zone.cloudflare_zone_{{ $resourceSuffix }}.id
-                name = "{{ $alternativeName }}"
-                value = "{{ $.Data.Hostname }}.{{ $.Data.DNSZone }}"
-                type = "CNAME"
-                ttl = 300
-            }
-        {{- end }}
+    resource "cloudflare_record" "{{ $recordResourceName }}" {
+        provider = cloudflare.cloudflare_dns_{{ $resourceSuffix }}
+        zone_id = data.cloudflare_zone.cloudflare_zone_{{ $resourceSuffix }}.id
+        name = "{{ $alternativeName }}"
+        value = "{{ $.Data.Hostname }}.{{ $.Data.DNSZone }}"
+        type = "CNAME"
+        ttl = 300
+    }
 
 	output "{{ $clusterID }}_{{ $alternativeName }}_{{ $resourceSuffix }}" {
 	  value = { "{{ $clusterID }}-{{ $alternativeName }}-endpoint" = format("%s.%s", "{{ $alternativeName }}", "{{ $.Data.DNSZone }}")}

--- a/templates/terraformer/cloudflare/dns/dns_alternative_names.tpl
+++ b/templates/terraformer/cloudflare/dns/dns_alternative_names.tpl
@@ -14,7 +14,7 @@
                 provider = cloudflare.cloudflare_dns_{{ $resourceSuffix }}
                 zone_id = data.cloudflare_zone.cloudflare_zone_{{ $resourceSuffix }}.id
                 name = "{{ $alternativeName }}"
-                value = "{{ $.Data.Hostname }}.{{ .Data.DNSZone }}"
+                value = "{{ $.Data.Hostname }}.{{ $.Data.DNSZone }}"
                 type = "CNAME"
                 ttl = 300
             }

--- a/templates/terraformer/gcp/dns/dns.tpl
+++ b/templates/terraformer/gcp/dns/dns.tpl
@@ -1,4 +1,5 @@
 {{- $specName          := .Data.Provider.SpecName }}
+{{- $hostname          := .Data.Hostname }}
 {{- $gcpProject        := .Data.Provider.GetGcp.Project }}
 {{- $uniqueFingerPrint := .Fingerprint }}
 {{- $resourceSuffix    := printf "%s_%s" $specName $uniqueFingerPrint }}
@@ -10,6 +11,19 @@ provider "google" {
     alias       = "dns_gcp_{{ $resourceSuffix }}"
 }
 
+resource "google_compute_health_check" "gcp_health_check_{{ $resourceSuffix }}" {
+  provider = google.dns_gcp_{{ $resourceSuffix }}
+  name               = "health-check-{{ $hostname }}"
+  check_interval_sec = 30
+  timeout_sec        = 5
+  healthy_threshold  = 2
+  unhealthy_threshold = 2
+  tcp_health_check {
+    port = 6443
+  }
+  source_regions = ["europe-central2", "us-central1", "asia-northeast1"]
+}
+
 data "google_dns_managed_zone" "gcp_zone_{{ $resourceSuffix }}" {
   provider  = google.dns_gcp_{{ $resourceSuffix }}
   name      = "{{ .Data.DNSZone }}"
@@ -18,17 +32,25 @@ data "google_dns_managed_zone" "gcp_zone_{{ $resourceSuffix }}" {
 resource "google_dns_record_set" "record_{{ $resourceSuffix }}" {
   provider = google.dns_gcp_{{ $resourceSuffix }}
 
-  name = "{{ .Data.Hostname }}.${data.google_dns_managed_zone.gcp_zone_{{ $resourceSuffix }}.dns_name}"
+  name = "{{ $hostname }}.${data.google_dns_managed_zone.gcp_zone_{{ $resourceSuffix }}.dns_name}"
   type = "A"
   ttl  = 300
 
   managed_zone = data.google_dns_managed_zone.gcp_zone_{{ $resourceSuffix }}.name
 
-  rrdatas = [
-      {{- range $ip := .Data.RecordData.IP }}
+  routing_policy {
+    health_check = google_compute_health_check.gcp_health_check_{{ $resourceSuffix }}.id
+    wrr {
+      health_checked_targets {
+        external_endpoints = [
+        {{- range $ip := .Data.RecordData.IP }}
           "{{ $ip.V4 }}",
-      {{- end }}
-    ]
+        {{- end }}
+        ]
+      }
+      weight = 1
+    }
+  }
 }
 
 output "{{ $clusterID }}_{{ $specName }}_{{ $uniqueFingerPrint }}" {

--- a/templates/terraformer/gcp/dns/dns_alternative_names.tpl
+++ b/templates/terraformer/gcp/dns/dns_alternative_names.tpl
@@ -15,7 +15,7 @@
 	  ttl  = 300
 
 	  managed_zone = data.google_dns_managed_zone.gcp_zone_{{ $resourceSuffix }}.name
-	  rrdatas = ["{{ $alternativeName }}"]
+	  rrdatas = ["{{ $alternativeName }}.${data.google_dns_managed_zone.gcp_zone_{{ $resourceSuffix }}.dns_name}"]
 
 	}
 

--- a/templates/terraformer/gcp/dns/dns_alternative_names.tpl
+++ b/templates/terraformer/gcp/dns/dns_alternative_names.tpl
@@ -10,12 +10,12 @@
 	resource "google_dns_record_set" "record_{{ $alternativeName }}_{{ $resourceSuffix }}" {
 	  provider = google.dns_gcp_{{ $resourceSuffix }}
 
-	  name = "{{ $hostname }}.${data.google_dns_managed_zone.gcp_zone_{{ $resourceSuffix }}.dns_name}"
+	  name = "{{ $alternativeName }}.${data.google_dns_managed_zone.gcp_zone_{{ $resourceSuffix }}.dns_name}"
 	  type = "CNAME"
 	  ttl  = 300
 
 	  managed_zone = data.google_dns_managed_zone.gcp_zone_{{ $resourceSuffix }}.name
-	  rrdatas = ["{{ $alternativeName }}.${data.google_dns_managed_zone.gcp_zone_{{ $resourceSuffix }}.dns_name}"]
+	  rrdatas = ["{{ $hostname }}.${data.google_dns_managed_zone.gcp_zone_{{ $resourceSuffix }}.dns_name}"]
 
 	}
 

--- a/templates/terraformer/gcp/dns/dns_alternative_names.tpl
+++ b/templates/terraformer/gcp/dns/dns_alternative_names.tpl
@@ -1,4 +1,5 @@
 {{- $specName          := .Data.Provider.SpecName }}
+{{- $hostname          := .Data.Hostname }}
 {{- $uniqueFingerPrint := .Fingerprint }}
 {{- $resourceSuffix    := printf "%s_%s" $specName $uniqueFingerPrint }}
 {{- $clusterID 	       := printf "%s-%s" .Data.ClusterName .Data.ClusterHash }}
@@ -9,23 +10,17 @@
 	resource "google_dns_record_set" "record_{{ $alternativeName }}_{{ $resourceSuffix }}" {
 	  provider = google.dns_gcp_{{ $resourceSuffix }}
 
-	  name = "{{ $alternativeName }}.${data.google_dns_managed_zone.gcp_zone_{{ $resourceSuffix }}.dns_name}"
-	  type = "A"
+	  name = "{{ $alternativeName }}"
+	  type = "CNAME"
 	  ttl  = 300
 
 	  managed_zone = data.google_dns_managed_zone.gcp_zone_{{ $resourceSuffix }}.name
-
-	  rrdatas = [
-	      {{- range $ip := $.Data.RecordData.IP }}
-		  "{{ $ip.V4 }}",
-	      {{- end }}
-	    ]
+	  rrdatas = ["$hostname.${data.google_dns_managed_zone.gcp_zone_{{ $resourceSuffix }}.dns_name}"]
 
 	}
 
 	output "{{ $clusterID }}_{{ $alternativeName }}_{{ $resourceSuffix }}" {
 	  value = { "{{ $clusterID }}-{{ $alternativeName }}-endpoint" = google_dns_record_set.record_{{ $alternativeName }}_{{ $resourceSuffix }}.name }
 	}
-
 	{{- end }}
 {{- end }}

--- a/templates/terraformer/gcp/dns/dns_alternative_names.tpl
+++ b/templates/terraformer/gcp/dns/dns_alternative_names.tpl
@@ -10,12 +10,12 @@
 	resource "google_dns_record_set" "record_{{ $alternativeName }}_{{ $resourceSuffix }}" {
 	  provider = google.dns_gcp_{{ $resourceSuffix }}
 
-	  name = "{{ $alternativeName }}"
+	  name = "{{ $hostname }}.${data.google_dns_managed_zone.gcp_zone_{{ $resourceSuffix }}.dns_name}"
 	  type = "CNAME"
 	  ttl  = 300
 
 	  managed_zone = data.google_dns_managed_zone.gcp_zone_{{ $resourceSuffix }}.name
-	  rrdatas = ["$hostname.${data.google_dns_managed_zone.gcp_zone_{{ $resourceSuffix }}.dns_name}"]
+	  rrdatas = ["{{ $alternativeName }}"]
 
 	}
 

--- a/templates/terraformer/oci/dns/dns.tpl
+++ b/templates/terraformer/oci/dns/dns.tpl
@@ -20,9 +20,9 @@ data "oci_dns_zones" "oci_zone_{{ $resourceSuffix }}" {
 }
 
 resource "oci_health_checks_ping_monitor" "oci_health_checks_{{ $resourceSuffix }}" {
-  provider        = oci.dns_oci_{{ $resourceSuffix }}
-  compartment_id  = "{{ .Data.Provider.GetOci.CompartmentOCID }}"
-  display_name    = "health-check-{{ $hostname }}"
+  provider            = oci.dns_oci_{{ $resourceSuffix }}
+  compartment_id      = "{{ .Data.Provider.GetOci.CompartmentOCID }}"
+  display_name        = "health-check-{{ $hostname }}"
   interval_in_seconds = 30
   protocol = "TCP"
   port  = 6443
@@ -34,11 +34,11 @@ resource "oci_health_checks_ping_monitor" "oci_health_checks_{{ $resourceSuffix 
 }
 
 resource "oci_dns_steering_policy" "oci_steering_policy_{{ $resourceSuffix }}" {
-  provider        = oci.dns_oci_{{ $resourceSuffix }}
-  compartment_id  = "{{ .Data.Provider.GetOci.CompartmentOCID }}"
-  display_name    = "{{ $hostname }}.${data.oci_dns_zones.oci_zone_{{ $resourceSuffix }}.name}"
-  template        = "LOAD_BALANCE"
-  ttl             = 300
+  provider                = oci.dns_oci_{{ $resourceSuffix }}
+  compartment_id          = "{{ .Data.Provider.GetOci.CompartmentOCID }}"
+  display_name            = "{{ $hostname }}.${data.oci_dns_zones.oci_zone_{{ $resourceSuffix }}.name}"
+  template                = "LOAD_BALANCE"
+  ttl                     = 300
   health_check_monitor_id = oci_health_checks_ping_monitor.oci_health_checks_{{ $resourceSuffix }}.id
 
   {{- range $ip := .Data.RecordData.IP }}
@@ -80,17 +80,17 @@ resource "oci_dns_steering_policy" "oci_steering_policy_{{ $resourceSuffix }}" {
 }
 
 locals {
-  matching_zone = [for z in data.oci_dns_zones.oci_zone_{{ $resourceSuffix }}.zones : z if z.name == "${data.oci_dns_zones.oci_zone_{{ $resourceSuffix }}.name}"][0]
+  matching_zone_{{ $resourceSuffix }} = [for z in data.oci_dns_zones.oci_zone_{{ $resourceSuffix }}.zones : z if z.name == "${data.oci_dns_zones.oci_zone_{{ $resourceSuffix }}.name}"][0]
 }
 
 resource "oci_dns_steering_policy_attachment" "dns_steering_policy_attachment_{{ $resourceSuffix }}" {
   provider        = oci.dns_oci_{{ $resourceSuffix }}
 	domain_name = "{{ $hostname }}.${data.oci_dns_zones.oci_zone_{{ $resourceSuffix }}.name}"
 	steering_policy_id = oci_dns_steering_policy.oci_steering_policy_{{ $resourceSuffix }}.id
-	zone_id = local.matching_zone.id
+	zone_id = local.matching_zone_{{ $resourceSuffix }}.id
 
 }
 
-output "{{ $clusterID }}_{{ $specName }}_{{ $uniqueFingerPrint }}" {
+output "{{ $clusterID }}_{{ $resourceSuffix }}" {
   value = { "{{ $clusterID }}-endpoint" = "{{ $hostname }}.${data.oci_dns_zones.oci_zone_{{ $resourceSuffix }}.name}" }
 }

--- a/templates/terraformer/oci/dns/dns.tpl
+++ b/templates/terraformer/oci/dns/dns.tpl
@@ -1,4 +1,5 @@
 {{- $specName          := .Data.Provider.SpecName }}
+{{- $hostname          := .Data.Hostname }}
 {{- $uniqueFingerPrint := .Fingerprint }}
 {{- $resourceSuffix    := printf "%s_%s" $specName $uniqueFingerPrint }}
 {{- $clusterID         := printf "%s-%s" .Data.ClusterName .Data.ClusterHash }}
@@ -13,28 +14,83 @@ provider "oci" {
 }
 
 data "oci_dns_zones" "oci_zone_{{ $resourceSuffix }}" {
-    provider        = oci.dns_oci_{{ $resourceSuffix }}
-    compartment_id  = "{{ .Data.Provider.GetOci.CompartmentOCID }}"
-    name            = "{{ .Data.DNSZone }}"
+  provider        = oci.dns_oci_{{ $resourceSuffix }}
+  compartment_id  = "{{ .Data.Provider.GetOci.CompartmentOCID }}"
+  name            = "{{ .Data.DNSZone }}"
 }
 
-resource "oci_dns_rrset" "record_{{ $resourceSuffix }}" {
-    provider        = oci.dns_oci_{{ $resourceSuffix }}
-    domain          = "{{ .Data.Hostname }}.${data.oci_dns_zones.oci_zone_{{ $resourceSuffix }}.name}"
-    rtype           = "A"
-    zone_name_or_id = data.oci_dns_zones.oci_zone_{{ $resourceSuffix }}.name
-
-    compartment_id  = "{{ .Data.Provider.GetOci.CompartmentOCID }}"
+resource "oci_health_checks_ping_monitor" "oci_health_checks_{{ $resourceSuffix }}" {
+  provider        = oci.dns_oci_{{ $resourceSuffix }}
+  compartment_id  = "{{ .Data.Provider.GetOci.CompartmentOCID }}"
+  display_name    = "health-check-{{ $hostname }}"
+  interval_in_seconds = 30
+  protocol = "TCP"
+  port  = 6443
+  targets = [
     {{- range $ip := .Data.RecordData.IP }}
-    items {
-       domain = "{{ $.Data.Hostname }}.${data.oci_dns_zones.oci_zone_{{ $resourceSuffix }}.name}"
-       rdata  = "{{ $ip.V4 }}"
-       rtype  = "A"
-       ttl    = 300
+      "{{ $ip.V4 }}",
+    {{- end }}
+  ]
+}
+
+resource "oci_dns_steering_policy" "oci_steering_policy_{{ $resourceSuffix }}" {
+  provider        = oci.dns_oci_{{ $resourceSuffix }}
+  compartment_id  = "{{ .Data.Provider.GetOci.CompartmentOCID }}"
+  display_name    = "{{ $hostname }}.${data.oci_dns_zones.oci_zone_{{ $resourceSuffix }}.name}"
+  template        = "LOAD_BALANCE"
+  ttl             = 300
+  health_check_monitor_id = oci_health_checks_ping_monitor.oci_health_checks_{{ $resourceSuffix }}.id
+
+  {{- range $ip := .Data.RecordData.IP }}
+  answers {
+    name = "{{ $ip.V4 }}.${data.oci_dns_zones.oci_zone_{{ $resourceSuffix }}.name}"
+    rdata = "{{ $ip.V4 }}"
+    rtype = "A"
+  }
+  {{- end }}
+
+  rules {
+    rule_type   = "FILTER"
+    description = "Removes disabled answers."
+    default_answer_data {
+        answer_condition = "answer.isDisabled != true"
+        should_keep      = "true"
+    }
+  }
+
+  rules {
+    rule_type   = "HEALTH"
+    description = "Removes unhealthy target"
+  }
+
+  rules {
+		rule_type = "WEIGHTED" 
+    {{- range $ip := .Data.RecordData.IP }}
+    default_answer_data {
+      answer_condition = "answer.name == '{{ $ip.V4 }}.${data.oci_dns_zones.oci_zone_{{ $resourceSuffix }}.name}'"
+      value = 1
     }
     {{- end }}
+  }
+
+  rules {
+    rule_type = "LIMIT"
+    default_count = "1"
+  }
 }
 
-output "{{ $clusterID }}_{{ $resourceSuffix }}" {
-  value = { "{{ $clusterID }}-endpoint" = oci_dns_rrset.record_{{ $resourceSuffix }}.domain }
+locals {
+  matching_zone = [for z in data.oci_dns_zones.oci_zone_{{ $resourceSuffix }}.zones : z if z.name == "${data.oci_dns_zones.oci_zone_{{ $resourceSuffix }}.name}"][0]
+}
+
+resource "oci_dns_steering_policy_attachment" "dns_steering_policy_attachment_{{ $resourceSuffix }}" {
+  provider        = oci.dns_oci_{{ $resourceSuffix }}
+	domain_name = "{{ $hostname }}.${data.oci_dns_zones.oci_zone_{{ $resourceSuffix }}.name}"
+	steering_policy_id = oci_dns_steering_policy.oci_steering_policy_{{ $resourceSuffix }}.id
+	zone_id = local.matching_zone.id
+
+}
+
+output "{{ $clusterID }}_{{ $specName }}_{{ $uniqueFingerPrint }}" {
+  value = { "{{ $clusterID }}-endpoint" = "{{ $hostname }}.${data.oci_dns_zones.oci_zone_{{ $resourceSuffix }}.name}" }
 }

--- a/templates/terraformer/oci/dns/dns_alternative_names.tpl
+++ b/templates/terraformer/oci/dns/dns_alternative_names.tpl
@@ -14,10 +14,10 @@
 		zone_name_or_id = data.oci_dns_zones.oci_zone_{{ $resourceSuffix }}.name
 
 		items {
-    		domain = "{{ $alternativeName }}.${data.oci_dns_zones.oci_zone_oci_8c4424dfe74de25fa9bc757883faf774.name}"
+    		domain = "{{ $alternativeName }}.${data.oci_dns_zones.oci_zone_{{ $resourceSuffix }}.name}"
 			rtype  = "CNAME"
 			ttl    = 300
-			rdata  = "{{ $hostname }}.${data.oci_dns_zones.oci_zone_oci_8c4424dfe74de25fa9bc757883faf774.name}"
+			rdata  = "{{ $hostname }}.${data.oci_dns_zones.oci_zone_{{ $resourceSuffix }}.name}"
   		}
 	}
 	output "{{ $clusterID }}_{{ $alternativeName }}_{{ $resourceSuffix }}" {

--- a/templates/terraformer/oci/dns/dns_alternative_names.tpl
+++ b/templates/terraformer/oci/dns/dns_alternative_names.tpl
@@ -4,6 +4,8 @@
 {{- $clusterID 	       := printf "%s-%s" .Data.ClusterName .Data.ClusterHash }}
 
 {{- if hasExtension .Data "AlternativeNamesExtension" }}
+	{{- range $_, $alternativeName := .Data.AlternativeNamesExtension.Names }}
+
 	resource "oci_dns_rrset" "record_{{ $alternativeName }}_{{ $resourceSuffix }}" {
 	   provider        = oci.dns_oci_{{ $resourceSuffix }}
 	   domain          = "{{ $alternativeName }}.${data.oci_dns_zones.oci_zone_{{ $resourceSuffix }}.name}"
@@ -17,4 +19,5 @@
 	output "{{ $clusterID }}_{{ $alternativeName }}_{{ $resourceSuffix }}" {
 	  value = { "{{ $clusterID }}-{{ $alternativeName }}-endpoint" = oci_dns_rrset.record_{{ $alternativeName }}_{{ $resourceSuffix }}.domain }
 	}
+	{{- end }}
 {{- end }}

--- a/templates/terraformer/oci/dns/dns_alternative_names.tpl
+++ b/templates/terraformer/oci/dns/dns_alternative_names.tpl
@@ -4,29 +4,17 @@
 {{- $clusterID 	       := printf "%s-%s" .Data.ClusterName .Data.ClusterHash }}
 
 {{- if hasExtension .Data "AlternativeNamesExtension" }}
-	{{- range $_, $alternativeName := .Data.AlternativeNamesExtension.Names }}
-
 	resource "oci_dns_rrset" "record_{{ $alternativeName }}_{{ $resourceSuffix }}" {
 	   provider        = oci.dns_oci_{{ $resourceSuffix }}
 	   domain          = "{{ $alternativeName }}.${data.oci_dns_zones.oci_zone_{{ $resourceSuffix }}.name}"
-	   rtype           = "A"
+	   rtype           = "CNAME"
 	   zone_name_or_id = data.oci_dns_zones.oci_zone_{{ $resourceSuffix }}.name
 
 	   compartment_id  = "{{ $.Data.Provider.GetOci.CompartmentOCID }}"
-	   {{- range $ip := $.Data.RecordData.IP }}
-	   items {
-	       domain  = "{{ $alternativeName }}.${data.oci_dns_zones.oci_zone_{{ $resourceSuffix }}.name}"
-           rdata   = "{{ $ip.V4 }}"
-           rtype   = "A"
-           ttl     =  300
-	   }
-	   {{- end }}
+	   rdata   		   = "{{ $alternativeName }}"
 	}
-
 
 	output "{{ $clusterID }}_{{ $alternativeName }}_{{ $resourceSuffix }}" {
 	  value = { "{{ $clusterID }}-{{ $alternativeName }}-endpoint" = oci_dns_rrset.record_{{ $alternativeName }}_{{ $resourceSuffix }}.domain }
 	}
-
-	{{- end }}
 {{- end }}

--- a/templates/terraformer/oci/dns/dns_alternative_names.tpl
+++ b/templates/terraformer/oci/dns/dns_alternative_names.tpl
@@ -1,3 +1,4 @@
+{{- $hostname          := .Data.Hostname }}
 {{- $specName          := .Data.Provider.SpecName }}
 {{- $uniqueFingerPrint := .Fingerprint }}
 {{- $resourceSuffix    := printf "%s_%s" $specName $uniqueFingerPrint }}
@@ -7,15 +8,18 @@
 	{{- range $_, $alternativeName := .Data.AlternativeNamesExtension.Names }}
 
 	resource "oci_dns_rrset" "record_{{ $alternativeName }}_{{ $resourceSuffix }}" {
-	   provider        = oci.dns_oci_{{ $resourceSuffix }}
-	   domain          = "{{ $alternativeName }}.${data.oci_dns_zones.oci_zone_{{ $resourceSuffix }}.name}"
-	   rtype           = "CNAME"
-	   zone_name_or_id = data.oci_dns_zones.oci_zone_{{ $resourceSuffix }}.name
+		provider        = oci.dns_oci_{{ $resourceSuffix }}
+		domain          = "{{ $alternativeName }}.${data.oci_dns_zones.oci_zone_{{ $resourceSuffix }}.name}"
+		rtype           = "CNAME"
+		zone_name_or_id = data.oci_dns_zones.oci_zone_{{ $resourceSuffix }}.name
 
-	   compartment_id  = "{{ $.Data.Provider.GetOci.CompartmentOCID }}"
-	   rdata   		   = "{{ $alternativeName }}"
+		items {
+    		domain = "{{ $alternativeName }}.${data.oci_dns_zones.oci_zone_oci_8c4424dfe74de25fa9bc757883faf774.name}"
+			rtype  = "CNAME"
+			ttl    = 300
+			rdata  = "{{ $hostname }}.${data.oci_dns_zones.oci_zone_oci_8c4424dfe74de25fa9bc757883faf774.name}"
+  		}
 	}
-
 	output "{{ $clusterID }}_{{ $alternativeName }}_{{ $resourceSuffix }}" {
 	  value = { "{{ $clusterID }}-{{ $alternativeName }}-endpoint" = oci_dns_rrset.record_{{ $alternativeName }}_{{ $resourceSuffix }}.domain }
 	}


### PR DESCRIPTION
Refers to: https://github.com/berops/claudie/issues/1759

- Add DNS load balancing functionality to Go templates for providers that support it: AWS, Azure, Cloudflare, GCP, and OCI
