### PR TITLE
update healthcheck port for claudie loadbalancers

### DIFF
--- a/templates/terraformer/aws/dns/dns.tpl
+++ b/templates/terraformer/aws/dns/dns.tpl
@@ -36,16 +36,17 @@ data "aws_route53_zone" "aws_zone_{{ $resourceSuffix }}" {
     ]
 
     set_identifier  = "record_{{ $hostname }}_{{ $escapedIPv4 }}_{{ $resourceSuffix }}"
-    health_check_id = aws_route53_health_check.hc_{{ $hostname }}_{{ $escapedIPv4 }}.id
+    health_check_id = aws_route53_health_check.hc_{{ $hostname }}_{{ $escapedIPv4 }}_{{ $resourceSuffix }}.id
 
     weighted_routing_policy {
       weight = 1
     }
   }
 
-  resource "aws_route53_health_check" "hc_{{ $hostname }}_{{ $escapedIPv4 }}" {
+  resource "aws_route53_health_check" "hc_{{ $hostname }}_{{ $escapedIPv4 }}_{{ $resourceSuffix }}" {
     provider          = aws.dns_aws_{{ $resourceSuffix }}
-    port              = 6443
+    # Claudie creates a default role for loadbalancers which acts as a healthcheck, that is open on port 65534
+    port              = 65534
     type              = "TCP"
     request_interval  = 30
     failure_threshold = 3

--- a/templates/terraformer/azure/dns/dns.tpl
+++ b/templates/terraformer/azure/dns/dns.tpl
@@ -32,7 +32,8 @@ resource "azurerm_traffic_manager_profile" "traffic_manager_{{ $hostname }}_{{ $
 
   monitor_config {
     protocol = "TCP"
-    port     = 6443
+    # Claudie creates a default role for loadbalancers which acts as a healthcheck, that is open on port 65534
+    port     = 65534
   }
 }
 

--- a/templates/terraformer/cloudflare/dns/dns.tpl
+++ b/templates/terraformer/cloudflare/dns/dns.tpl
@@ -30,7 +30,7 @@ data "cloudflare_zone" "cloudflare_zone_{{ $resourceSuffix }}" {
         weight  = 1
       }
     {{- end }}
-      
+
       monitor = cloudflare_load_balancer_monitor.monitor_{{ $resourceSuffix }}.id
   }
 
@@ -38,7 +38,8 @@ data "cloudflare_zone" "cloudflare_zone_{{ $resourceSuffix }}" {
     provider    = cloudflare.cloudflare_dns_{{ $resourceSuffix }}
     account_id  = "{{ .Data.Provider.GetCloudflare.GetAccountID }}"
     type        = "tcp"
-    port        = 6443
+    # Claudie creates a default role for loadbalancers which acts as a healthcheck, that is open on port 65534
+    port        = 65534
     timeout     = 5
     retries     = 2
     interval    = 60
@@ -57,9 +58,6 @@ data "cloudflare_zone" "cloudflare_zone_{{ $resourceSuffix }}" {
 
     steering_policy="random"
   }
-  output "{{ $clusterID }}_{{ $resourceSuffix }}" {
-    value = { "{{ $clusterID }}-endpoint" = format("%s.%s", "{{ .Data.Hostname }}", "{{ .Data.DNSZone }}")}
-  }
 ### If subscription does not include claudflare paid addon
 ### for DNS balancing, create DNS A records with no health check
 {{- else }}
@@ -75,8 +73,9 @@ data "cloudflare_zone" "cloudflare_zone_{{ $resourceSuffix }}" {
       type     = "A"
       ttl      = 300
     }
-  {{- end }} 
-  output "{{ $clusterID }}_{{ $resourceSuffix }}" {
-    value = { "{{ $clusterID }}-endpoint" = format("%s.%s", "{{ .Data.Hostname }}", "{{ .Data.DNSZone }}")}
-  }
+  {{- end }}
 {{- end }}
+
+output "{{ $clusterID }}_{{ $resourceSuffix }}" {
+    value = { "{{ $clusterID }}-endpoint" = format("%s.%s", "{{ .Data.Hostname }}", "{{ .Data.DNSZone }}")}
+}

--- a/templates/terraformer/gcp/dns/dns.tpl
+++ b/templates/terraformer/gcp/dns/dns.tpl
@@ -19,7 +19,8 @@ resource "google_compute_health_check" "gcp_health_check_{{ $resourceSuffix }}" 
   healthy_threshold  = 2
   unhealthy_threshold = 2
   tcp_health_check {
-    port = 6443
+    # Claudie creates a default role for loadbalancers which acts as a healthcheck, that is open on port 65534
+    port = 65534
   }
   source_regions = ["europe-central2", "us-central1", "asia-northeast1"]
 }

--- a/templates/terraformer/gcp/dns/dns_alternative_names.tpl
+++ b/templates/terraformer/gcp/dns/dns_alternative_names.tpl
@@ -16,7 +16,6 @@
 
 	  managed_zone = data.google_dns_managed_zone.gcp_zone_{{ $resourceSuffix }}.name
 	  rrdatas = ["{{ $hostname }}.${data.google_dns_managed_zone.gcp_zone_{{ $resourceSuffix }}.dns_name}"]
-
 	}
 
 	output "{{ $clusterID }}_{{ $alternativeName }}_{{ $resourceSuffix }}" {


### PR DESCRIPTION
with https://github.com/berops/claudie/pull/1735

claudie has a static healthcheck port on every loadbalancer node accessible via port `65534`