### PR TITLE
TF resources update to work with latest versions

### DIFF
--- a/templates/terraformer/cloudflare/dns/dns.tpl
+++ b/templates/terraformer/cloudflare/dns/dns.tpl
@@ -65,7 +65,7 @@ data "cloudflare_zone" "cloudflare_zone_{{ $resourceSuffix }}" {
     {{- $escapedIPv4 := replaceAll $ip.V4 "." "_"}}
     {{- $recordResourceName := printf "record_%s_%s" $escapedIPv4 $resourceSuffix }}
 
-    resource "cloudflare_record" "{{ $recordResourceName }}" {
+    resource "cloudflare_dns_record" "{{ $recordResourceName }}" {
       provider = cloudflare.cloudflare_dns_{{ $resourceSuffix }}
       zone_id  = data.cloudflare_zone.cloudflare_zone_{{ $resourceSuffix }}.id
       name     = "{{ $.Data.Hostname }}"

--- a/templates/terraformer/cloudflare/dns/dns_alternative_names.tpl
+++ b/templates/terraformer/cloudflare/dns/dns_alternative_names.tpl
@@ -7,7 +7,7 @@
 	{{- range $_, $alternativeName := .Data.AlternativeNamesExtension.Names }}
     {{- $recordResourceName := printf "record_%s_%s" $alternativeName $resourceSuffix }}
 
-    resource "cloudflare_record" "{{ $recordResourceName }}" {
+    resource "cloudflare_dns_record" "{{ $recordResourceName }}" {
         provider = cloudflare.cloudflare_dns_{{ $resourceSuffix }}
         zone_id = data.cloudflare_zone.cloudflare_zone_{{ $resourceSuffix }}.id
         name = "{{ $alternativeName }}"


### PR DESCRIPTION
Required changes in tf provider templates to work with latest versions:

https://github.com/berops/claudie/issues/1775

```
source  = "hetznercloud/hcloud"
version = "1.51.0"

source  = "hashicorp/google"
version = "6.44.0"

source  = "hashicorp/aws"
version = "6.4.0"

source  = "oracle/oci"
version = "7.10.0"

source  = "hashicorp/azurerm"
version = "4.37.0"

source  = "cloudflare/cloudflare"
version = "5.7.1"

source  = "timohirt/hetznerdns"
version = "2.2.0"

source = "genesiscloud/genesiscloud"
version = "1.1.14"
```
