### PR TITLE
Bug/healthcheck collision

### DIFF
--- a/templates/terraformer/azure/dns/dns.tpl
+++ b/templates/terraformer/azure/dns/dns.tpl
@@ -5,7 +5,7 @@
 {{- $clusterID         := printf "%s-%s" .Data.ClusterName .Data.ClusterHash }}
 {{- $sha256Input       := printf "traffic-manager-%s-%s-%s" $hostname $clusterID $uniqueFingerPrint }}
 {{- $sha256Hash        := trunc 58 (sha256sum $sha256Input) }}
-{{- $trafficManagerName := printf "tm%s%s" $sha256Hash }}
+{{- $trafficManagerName := printf "tm%s" $sha256Hash }}
 
 provider "azurerm" {
   features {}

--- a/templates/terraformer/azure/dns/dns.tpl
+++ b/templates/terraformer/azure/dns/dns.tpl
@@ -23,7 +23,7 @@ data "azurerm_dns_zone" "azure_zone_{{ $resourceSuffix }}" {
 
 resource "azurerm_traffic_manager_profile" "traffic_manager_{{ $hostname }}_{{ $resourceSuffix}}" {
   provider            = azurerm.dns_azure_{{ $resourceSuffix }}
-  name                = "traffic-manager-{{ $trafficManagerName }}""
+  name                = "traffic-manager-{{ $trafficManagerName }}"
   resource_group_name = data.azurerm_dns_zone.azure_zone_{{ $resourceSuffix }}.resource_group_name
 
   traffic_routing_method = "Weighted"

--- a/templates/terraformer/azure/dns/dns.tpl
+++ b/templates/terraformer/azure/dns/dns.tpl
@@ -20,7 +20,7 @@ data "azurerm_dns_zone" "azure_zone_{{ $resourceSuffix }}" {
 
 resource "azurerm_traffic_manager_profile" "traffic_manager_{{ $hostname }}_{{ $resourceSuffix}}" {
   provider            = azurerm.dns_azure_{{ $resourceSuffix }}
-  name                = "traffic-manager-{{ $hostname }}-{{ $clusterID }}"
+  name                = "traffic-manager-{{ $hostname }}-{{ $clusterID }}-{{ $uniqueFingerPrint }}""
   resource_group_name = data.azurerm_dns_zone.azure_zone_{{ $resourceSuffix }}.resource_group_name
 
   traffic_routing_method = "Weighted"

--- a/templates/terraformer/azure/dns/dns.tpl
+++ b/templates/terraformer/azure/dns/dns.tpl
@@ -20,7 +20,7 @@ data "azurerm_dns_zone" "azure_zone_{{ $resourceSuffix }}" {
 
 resource "azurerm_traffic_manager_profile" "traffic_manager_{{ $hostname }}_{{ $resourceSuffix}}" {
   provider            = azurerm.dns_azure_{{ $resourceSuffix }}
-  name                = "traffic-manager-{{ $hostname }}"
+  name                = "traffic-manager-{{ $hostname }}-{{ $clusterID }}"
   resource_group_name = data.azurerm_dns_zone.azure_zone_{{ $resourceSuffix }}.resource_group_name
 
   traffic_routing_method = "Weighted"

--- a/templates/terraformer/azure/dns/dns.tpl
+++ b/templates/terraformer/azure/dns/dns.tpl
@@ -4,7 +4,8 @@
 {{- $resourceSuffix    := printf "%s_%s" $specName $uniqueFingerPrint }}
 {{- $clusterID         := printf "%s-%s" .Data.ClusterName .Data.ClusterHash }}
 {{- $sha256Input       := printf "traffic-manager-%s-%s-%s" $hostname $clusterID $uniqueFingerPrint }}
-{{- $trafficManagerName := printf "tm%s%s" .Data.ClusterHash sha256sum $sha256Input }}
+{{- $sha256Hash        := sha256sum $sha256Input }}
+{{- $trafficManagerName := printf "tm%s%s" .Data.ClusterHash $sha256Hash }}
 
 provider "azurerm" {
   features {}

--- a/templates/terraformer/azure/dns/dns.tpl
+++ b/templates/terraformer/azure/dns/dns.tpl
@@ -26,7 +26,7 @@ resource "azurerm_traffic_manager_profile" "traffic_manager_{{ $hostname }}_{{ $
   traffic_routing_method = "Weighted"
 
   dns_config {
-    relative_name = "{{ $hostname }}-{{ $clusterID }}"
+    relative_name = "{{ $hostname }}-{{ $clusterID }}-{{ uniqueFingerPrint }}"
     ttl           = 30
   }
 

--- a/templates/terraformer/azure/dns/dns.tpl
+++ b/templates/terraformer/azure/dns/dns.tpl
@@ -4,8 +4,8 @@
 {{- $resourceSuffix    := printf "%s_%s" $specName $uniqueFingerPrint }}
 {{- $clusterID         := printf "%s-%s" .Data.ClusterName .Data.ClusterHash }}
 {{- $sha256Input       := printf "traffic-manager-%s-%s-%s" $hostname $clusterID $uniqueFingerPrint }}
-{{- $sha256Hash        := sha256sum $sha256Input }}
-{{- $trafficManagerName := printf "tm%s%s" .Data.ClusterHash $sha256Hash }}
+{{- $sha256Hash        := trunc 58 (sha256sum $sha256Input) }}
+{{- $trafficManagerName := printf "tm%s%s" $sha256Hash }}
 
 provider "azurerm" {
   features {}

--- a/templates/terraformer/azure/dns/dns.tpl
+++ b/templates/terraformer/azure/dns/dns.tpl
@@ -26,7 +26,7 @@ resource "azurerm_traffic_manager_profile" "traffic_manager_{{ $hostname }}_{{ $
   traffic_routing_method = "Weighted"
 
   dns_config {
-    relative_name = "{{ $hostname }}"
+    relative_name = "{{ $hostname }}-{{ $clusterID }}"
     ttl           = 30
   }
 

--- a/templates/terraformer/azure/dns/dns.tpl
+++ b/templates/terraformer/azure/dns/dns.tpl
@@ -3,6 +3,8 @@
 {{- $uniqueFingerPrint := .Fingerprint }}
 {{- $resourceSuffix    := printf "%s_%s" $specName $uniqueFingerPrint }}
 {{- $clusterID         := printf "%s-%s" .Data.ClusterName .Data.ClusterHash }}
+{{- $sha256Input       := printf "traffic-manager-%s-%s-%s" $hostname $clusterID $uniqueFingerPrint }}
+{{- $trafficManagerName := printf "tm%s%s" .Data.ClusterHash sha256sum $sha256Input }}
 
 provider "azurerm" {
   features {}
@@ -20,13 +22,13 @@ data "azurerm_dns_zone" "azure_zone_{{ $resourceSuffix }}" {
 
 resource "azurerm_traffic_manager_profile" "traffic_manager_{{ $hostname }}_{{ $resourceSuffix}}" {
   provider            = azurerm.dns_azure_{{ $resourceSuffix }}
-  name                = "traffic-manager-{{ $hostname }}-{{ $clusterID }}-{{ $uniqueFingerPrint }}""
+  name                = "traffic-manager-{{ $trafficManagerName }}""
   resource_group_name = data.azurerm_dns_zone.azure_zone_{{ $resourceSuffix }}.resource_group_name
 
   traffic_routing_method = "Weighted"
 
   dns_config {
-    relative_name = "{{ $hostname }}-{{ $clusterID }}-{{ $uniqueFingerPrint }}"
+    relative_name = "{{ $trafficManagerName }}"
     ttl           = 30
   }
 

--- a/templates/terraformer/azure/dns/dns.tpl
+++ b/templates/terraformer/azure/dns/dns.tpl
@@ -26,7 +26,7 @@ resource "azurerm_traffic_manager_profile" "traffic_manager_{{ $hostname }}_{{ $
   traffic_routing_method = "Weighted"
 
   dns_config {
-    relative_name = "{{ $hostname }}-{{ $clusterID }}-{{ uniqueFingerPrint }}"
+    relative_name = "{{ $hostname }}-{{ $clusterID }}-{{ $uniqueFingerPrint }}"
     ttl           = 30
   }
 

--- a/templates/terraformer/cloudflare/dns/dns.tpl
+++ b/templates/terraformer/cloudflare/dns/dns.tpl
@@ -1,3 +1,4 @@
+{{- $hostname          := .Data.Hostname }}
 {{- $specName          := .Data.Provider.SpecName }}
 {{- $uniqueFingerPrint := .Fingerprint }}
 {{- $resourceSuffix    := printf "%s_%s" $specName $uniqueFingerPrint }}

--- a/templates/terraformer/cloudflare/dns/dns.tpl
+++ b/templates/terraformer/cloudflare/dns/dns.tpl
@@ -4,7 +4,8 @@
 {{- $resourceSuffix    := printf "%s_%s" $specName $uniqueFingerPrint }}
 {{- $clusterID         := printf "%s-%s" .Data.ClusterName .Data.ClusterHash }}
 {{- $sha256Input       := printf "pool-name-%s-%s-%s" $hostname $clusterID $uniqueFingerPrint }}
-{{- $poolName          := printf "pn%s%s" .Data.ClusterHash sha256sum $sha256Input }}
+{{- $sha256Hash        := sha256sum $sha256Input }}
+{{- $poolName          := printf "pn%s%s" .Data.ClusterHash $sha256Hash }}
 
 provider "cloudflare" {
   api_token = "${file("{{ $specName }}")}"

--- a/templates/terraformer/cloudflare/dns/dns.tpl
+++ b/templates/terraformer/cloudflare/dns/dns.tpl
@@ -20,7 +20,7 @@ data "cloudflare_zone" "cloudflare_zone_{{ $resourceSuffix }}" {
   resource "cloudflare_load_balancer_pool" "lb_pool_{{ $resourceSuffix }}" {
     provider    = cloudflare.cloudflare_dns_{{ $resourceSuffix }}
     account_id  = "{{ .Data.Provider.GetCloudflare.GetAccountID }}"
-    name        = "pool-{{ $resourceSuffix }}"
+    name        = "pool-{{ $$clusterID }}-{{ $uniqueFingerPrint }}"
 
     {{- range $_, $ip := .Data.RecordData.IP }}
       {{- $escapedIPv4 := replaceAll $ip.V4 "." "_" }}

--- a/templates/terraformer/cloudflare/dns/dns.tpl
+++ b/templates/terraformer/cloudflare/dns/dns.tpl
@@ -20,7 +20,7 @@ data "cloudflare_zone" "cloudflare_zone_{{ $resourceSuffix }}" {
   resource "cloudflare_load_balancer_pool" "lb_pool_{{ $resourceSuffix }}" {
     provider    = cloudflare.cloudflare_dns_{{ $resourceSuffix }}
     account_id  = "{{ .Data.Provider.GetCloudflare.GetAccountID }}"
-    name        = "pool-{{ $$clusterID }}-{{ $uniqueFingerPrint }}"
+    name        = "pool-{{ $clusterID }}-{{ $uniqueFingerPrint }}"
 
     {{- range $_, $ip := .Data.RecordData.IP }}
       {{- $escapedIPv4 := replaceAll $ip.V4 "." "_" }}

--- a/templates/terraformer/cloudflare/dns/dns.tpl
+++ b/templates/terraformer/cloudflare/dns/dns.tpl
@@ -5,7 +5,7 @@
 {{- $clusterID         := printf "%s-%s" .Data.ClusterName .Data.ClusterHash }}
 {{- $sha256Input       := printf "pool-name-%s-%s-%s" $hostname $clusterID $uniqueFingerPrint }}
 {{- $sha256Hash        := trunc 58 (sha256sum $sha256Input) }}
-{{- $poolName          := printf "pn%s%s" $sha256Hash }}
+{{- $poolName          := printf "pn%s" $sha256Hash }}
 
 provider "cloudflare" {
   api_token = "${file("{{ $specName }}")}"

--- a/templates/terraformer/cloudflare/dns/dns.tpl
+++ b/templates/terraformer/cloudflare/dns/dns.tpl
@@ -2,6 +2,8 @@
 {{- $uniqueFingerPrint := .Fingerprint }}
 {{- $resourceSuffix    := printf "%s_%s" $specName $uniqueFingerPrint }}
 {{- $clusterID         := printf "%s-%s" .Data.ClusterName .Data.ClusterHash }}
+{{- $sha256Input       := printf "pool-name-%s-%s-%s" $hostname $clusterID $uniqueFingerPrint }}
+{{- $poolName          := printf "pn%s%s" .Data.ClusterHash sha256sum $sha256Input }}
 
 provider "cloudflare" {
   api_token = "${file("{{ $specName }}")}"
@@ -20,7 +22,7 @@ data "cloudflare_zone" "cloudflare_zone_{{ $resourceSuffix }}" {
   resource "cloudflare_load_balancer_pool" "lb_pool_{{ $resourceSuffix }}" {
     provider    = cloudflare.cloudflare_dns_{{ $resourceSuffix }}
     account_id  = "{{ .Data.Provider.GetCloudflare.GetAccountID }}"
-    name        = "pool-{{ $clusterID }}-{{ $uniqueFingerPrint }}"
+    name        = "pool-{{ $poolName }}"
 
     {{- range $_, $ip := .Data.RecordData.IP }}
       {{- $escapedIPv4 := replaceAll $ip.V4 "." "_" }}

--- a/templates/terraformer/cloudflare/dns/dns.tpl
+++ b/templates/terraformer/cloudflare/dns/dns.tpl
@@ -4,8 +4,8 @@
 {{- $resourceSuffix    := printf "%s_%s" $specName $uniqueFingerPrint }}
 {{- $clusterID         := printf "%s-%s" .Data.ClusterName .Data.ClusterHash }}
 {{- $sha256Input       := printf "pool-name-%s-%s-%s" $hostname $clusterID $uniqueFingerPrint }}
-{{- $sha256Hash        := sha256sum $sha256Input }}
-{{- $poolName          := printf "pn%s%s" .Data.ClusterHash $sha256Hash }}
+{{- $sha256Hash        := trunc 58 (sha256sum $sha256Input) }}
+{{- $poolName          := printf "pn%s%s" $sha256Hash }}
 
 provider "cloudflare" {
   api_token = "${file("{{ $specName }}")}"

--- a/templates/terraformer/gcp/dns/dns.tpl
+++ b/templates/terraformer/gcp/dns/dns.tpl
@@ -13,7 +13,7 @@ provider "google" {
 
 resource "google_compute_health_check" "gcp_health_check_{{ $resourceSuffix }}" {
   provider = google.dns_gcp_{{ $resourceSuffix }}
-  name               = "health-check-{{ $hostname }}-{{ $clusterID }}-{{ uniqueFingerPrint }}"
+  name               = "health-check-{{ $hostname }}-{{ $clusterID }}-{{ $uniqueFingerPrint }}"
   check_interval_sec = 30
   timeout_sec        = 5
   healthy_threshold  = 2

--- a/templates/terraformer/gcp/dns/dns.tpl
+++ b/templates/terraformer/gcp/dns/dns.tpl
@@ -13,7 +13,7 @@ provider "google" {
 
 resource "google_compute_health_check" "gcp_health_check_{{ $resourceSuffix }}" {
   provider = google.dns_gcp_{{ $resourceSuffix }}
-  name               = "health-check-{{ $hostname }}-{{ $clusterID }}"
+  name               = "health-check-{{ $hostname }}-{{ $clusterID }}-{{ uniqueFingerPrint }}"
   check_interval_sec = 30
   timeout_sec        = 5
   healthy_threshold  = 2

--- a/templates/terraformer/gcp/dns/dns.tpl
+++ b/templates/terraformer/gcp/dns/dns.tpl
@@ -13,7 +13,9 @@ provider "google" {
 
 resource "google_compute_health_check" "gcp_health_check_{{ $resourceSuffix }}" {
   provider = google.dns_gcp_{{ $resourceSuffix }}
-  name               = "trunc 60 health-check-{{ $hostname }}-{{ $clusterID }}-{{ $uniqueFingerPrint }}"
+  {{- $name := printf "health-check-%s-%s-%s" $hostname $clusterID $uniqueFingerPrint -}}
+  {{- $truncatedName := trunc 60 $name -}} 
+  name               = "{{ $truncatedName }}"
   check_interval_sec = 30
   timeout_sec        = 5
   healthy_threshold  = 2

--- a/templates/terraformer/gcp/dns/dns.tpl
+++ b/templates/terraformer/gcp/dns/dns.tpl
@@ -5,8 +5,8 @@
 {{- $resourceSuffix    := printf "%s_%s" $specName $uniqueFingerPrint }}
 {{- $clusterID         := printf "%s-%s" .Data.ClusterName .Data.ClusterHash }}
 {{- $sha256Input       := printf "health-check-%s-%s-%s" $hostname $clusterID $uniqueFingerPrint }}
-{{- $sha256Hash        := sha256sum $sha256Input }}
-{{- $healthCheckName   := printf "hc%s%s" .Data.ClusterHash $sha256Hash }}
+{{- $sha256Hash        := trunc 58 (sha256sum $sha256Input) }}
+{{- $healthCheckName   := printf "hc%s%s" $sha256Hash }}
 
 provider "google" {
     credentials = "${file("{{ $specName }}")}"

--- a/templates/terraformer/gcp/dns/dns.tpl
+++ b/templates/terraformer/gcp/dns/dns.tpl
@@ -5,7 +5,8 @@
 {{- $resourceSuffix    := printf "%s_%s" $specName $uniqueFingerPrint }}
 {{- $clusterID         := printf "%s-%s" .Data.ClusterName .Data.ClusterHash }}
 {{- $sha256Input       := printf "health-check-%s-%s-%s" $hostname $clusterID $uniqueFingerPrint }}
-{{- $healthCheckName   := printf "hc%s%s" .Data.ClusterHash sha256sum $sha256Input }}
+{{- $sha256Hash        := sha256sum $sha256Input }}
+{{- $healthCheckName   := printf "hc%s%s" .Data.ClusterHash $sha256Hash }}
 
 provider "google" {
     credentials = "${file("{{ $specName }}")}"

--- a/templates/terraformer/gcp/dns/dns.tpl
+++ b/templates/terraformer/gcp/dns/dns.tpl
@@ -13,7 +13,7 @@ provider "google" {
 
 resource "google_compute_health_check" "gcp_health_check_{{ $resourceSuffix }}" {
   provider = google.dns_gcp_{{ $resourceSuffix }}
-  name               = "health-check-{{ $hostname }}-{{ $uniqueFingerPrint }}"
+  name               = "health-check-{{ $hostname }}-{{ $clusterID }}"
   check_interval_sec = 30
   timeout_sec        = 5
   healthy_threshold  = 2

--- a/templates/terraformer/gcp/dns/dns.tpl
+++ b/templates/terraformer/gcp/dns/dns.tpl
@@ -6,7 +6,7 @@
 {{- $clusterID         := printf "%s-%s" .Data.ClusterName .Data.ClusterHash }}
 {{- $sha256Input       := printf "health-check-%s-%s-%s" $hostname $clusterID $uniqueFingerPrint }}
 {{- $sha256Hash        := trunc 58 (sha256sum $sha256Input) }}
-{{- $healthCheckName   := printf "hc%s%s" $sha256Hash }}
+{{- $healthCheckName   := printf "hc%s" $sha256Hash }}
 
 provider "google" {
     credentials = "${file("{{ $specName }}")}"

--- a/templates/terraformer/gcp/dns/dns.tpl
+++ b/templates/terraformer/gcp/dns/dns.tpl
@@ -3,9 +3,8 @@
 {{- $gcpProject        := .Data.Provider.GetGcp.Project }}
 {{- $uniqueFingerPrint := .Fingerprint }}
 {{- $resourceSuffix    := printf "%s_%s" $specName $uniqueFingerPrint }}
-{{- $clusterID         := printf "%s-%s" .Data.ClusterName .Data.ClusterHash }}
-{{- $healthCheckName   := printf "health-check-%s-%s-%s" $hostname $clusterID $uniqueFingerPrint -}}
-{{- $truncatedHealthCheckName := trunc 60 $healthCheckName -}} 
+{{- $sha256Input       := printf "health-check-%s-%s-%s" $hostname $clusterID $uniqueFingerPrint }}
+{{- $healthCheckName   := printf "hc%s%s" .Data.ClusterHash sha256sum $sha256Input }}
 
 provider "google" {
     credentials = "${file("{{ $specName }}")}"
@@ -15,7 +14,7 @@ provider "google" {
 
 resource "google_compute_health_check" "gcp_health_check_{{ $resourceSuffix }}" {
   provider = google.dns_gcp_{{ $resourceSuffix }}
-  name               = "{{ $truncatedHealthCheckName }}"
+  name               = "{{ $healthCheckName }}"
   check_interval_sec = 30
   timeout_sec        = 5
   healthy_threshold  = 2

--- a/templates/terraformer/gcp/dns/dns.tpl
+++ b/templates/terraformer/gcp/dns/dns.tpl
@@ -4,6 +4,8 @@
 {{- $uniqueFingerPrint := .Fingerprint }}
 {{- $resourceSuffix    := printf "%s_%s" $specName $uniqueFingerPrint }}
 {{- $clusterID         := printf "%s-%s" .Data.ClusterName .Data.ClusterHash }}
+{{- $healthCheckName   := printf "health-check-%s-%s-%s" $hostname $clusterID $uniqueFingerPrint -}}
+{{- $truncatedHealthCheckName := trunc 60 $name -}} 
 
 provider "google" {
     credentials = "${file("{{ $specName }}")}"
@@ -13,9 +15,7 @@ provider "google" {
 
 resource "google_compute_health_check" "gcp_health_check_{{ $resourceSuffix }}" {
   provider = google.dns_gcp_{{ $resourceSuffix }}
-  {{- $name := printf "health-check-%s-%s-%s" $hostname $clusterID $uniqueFingerPrint -}}
-  {{- $truncatedName := trunc 60 $name -}} 
-  name               = "{{ $truncatedName }}"
+  name               = "{{ $truncatedHealthCheckName }}"
   check_interval_sec = 30
   timeout_sec        = 5
   healthy_threshold  = 2

--- a/templates/terraformer/gcp/dns/dns.tpl
+++ b/templates/terraformer/gcp/dns/dns.tpl
@@ -5,7 +5,7 @@
 {{- $resourceSuffix    := printf "%s_%s" $specName $uniqueFingerPrint }}
 {{- $clusterID         := printf "%s-%s" .Data.ClusterName .Data.ClusterHash }}
 {{- $healthCheckName   := printf "health-check-%s-%s-%s" $hostname $clusterID $uniqueFingerPrint -}}
-{{- $truncatedHealthCheckName := trunc 60 $name -}} 
+{{- $truncatedHealthCheckName := trunc 60 $healthCheckName -}} 
 
 provider "google" {
     credentials = "${file("{{ $specName }}")}"

--- a/templates/terraformer/gcp/dns/dns.tpl
+++ b/templates/terraformer/gcp/dns/dns.tpl
@@ -13,7 +13,7 @@ provider "google" {
 
 resource "google_compute_health_check" "gcp_health_check_{{ $resourceSuffix }}" {
   provider = google.dns_gcp_{{ $resourceSuffix }}
-  name               = "health-check-{{ $hostname }}-{{ $clusterID }}-{{ $uniqueFingerPrint }}"
+  name               = "trunc 60 health-check-{{ $hostname }}-{{ $clusterID }}-{{ $uniqueFingerPrint }}"
   check_interval_sec = 30
   timeout_sec        = 5
   healthy_threshold  = 2

--- a/templates/terraformer/gcp/dns/dns.tpl
+++ b/templates/terraformer/gcp/dns/dns.tpl
@@ -13,7 +13,7 @@ provider "google" {
 
 resource "google_compute_health_check" "gcp_health_check_{{ $resourceSuffix }}" {
   provider = google.dns_gcp_{{ $resourceSuffix }}
-  name               = "health-check-{{ $hostname }}-{{ $resourceSuffix }}"
+  name               = "health-check-{{ $hostname }}-{{ $uniqueFingerPrint }}"
   check_interval_sec = 30
   timeout_sec        = 5
   healthy_threshold  = 2

--- a/templates/terraformer/gcp/dns/dns.tpl
+++ b/templates/terraformer/gcp/dns/dns.tpl
@@ -3,6 +3,7 @@
 {{- $gcpProject        := .Data.Provider.GetGcp.Project }}
 {{- $uniqueFingerPrint := .Fingerprint }}
 {{- $resourceSuffix    := printf "%s_%s" $specName $uniqueFingerPrint }}
+{{- $clusterID         := printf "%s-%s" .Data.ClusterName .Data.ClusterHash }}
 {{- $sha256Input       := printf "health-check-%s-%s-%s" $hostname $clusterID $uniqueFingerPrint }}
 {{- $healthCheckName   := printf "hc%s%s" .Data.ClusterHash sha256sum $sha256Input }}
 

--- a/templates/terraformer/gcp/dns/dns.tpl
+++ b/templates/terraformer/gcp/dns/dns.tpl
@@ -13,7 +13,7 @@ provider "google" {
 
 resource "google_compute_health_check" "gcp_health_check_{{ $resourceSuffix }}" {
   provider = google.dns_gcp_{{ $resourceSuffix }}
-  name               = "health-check-{{ $hostname }}"
+  name               = "health-check-{{ $hostname }}-{{ $resourceSuffix }}"
   check_interval_sec = 30
   timeout_sec        = 5
   healthy_threshold  = 2

--- a/templates/terraformer/oci/dns/dns.tpl
+++ b/templates/terraformer/oci/dns/dns.tpl
@@ -4,7 +4,8 @@
 {{- $resourceSuffix    := printf "%s_%s" $specName $uniqueFingerPrint }}
 {{- $clusterID         := printf "%s-%s" .Data.ClusterName .Data.ClusterHash }}
 {{- $sha256Input       := printf "health-check-%s-%s-%s" $hostname $clusterID $uniqueFingerPrint }}
-{{- $healthCheckName   := printf "hc%s%s" .Data.ClusterHash sha256sum $sha256Input }}
+{{- $sha256Hash        := sha256sum $sha256Input }}
+{{- $healthCheckName   := printf "hc%s%s" .Data.ClusterHash $sha256Hash }}
 
 provider "oci" {
   tenancy_ocid      = "{{ .Data.Provider.GetOci.TenancyOCID }}"
@@ -39,7 +40,7 @@ resource "oci_health_checks_ping_monitor" "oci_health_checks_{{ $resourceSuffix 
 resource "oci_dns_steering_policy" "oci_steering_policy_{{ $resourceSuffix }}" {
   provider                = oci.dns_oci_{{ $resourceSuffix }}
   compartment_id          = "{{ .Data.Provider.GetOci.CompartmentOCID }}"
-  display_name            = "{{ $hostname }}-{{ $clusterID }}-{{ $uniqueFingerPrint }}.${data.oci_dns_zones.oci_zone_{{ $resourceSuffix }}.name}"
+  display_name            = "{{ $healthCheckName }}.${data.oci_dns_zones.oci_zone_{{ $resourceSuffix }}.name}"
   template                = "LOAD_BALANCE"
   ttl                     = 300
   health_check_monitor_id = oci_health_checks_ping_monitor.oci_health_checks_{{ $resourceSuffix }}.id

--- a/templates/terraformer/oci/dns/dns.tpl
+++ b/templates/terraformer/oci/dns/dns.tpl
@@ -22,7 +22,7 @@ data "oci_dns_zones" "oci_zone_{{ $resourceSuffix }}" {
 resource "oci_health_checks_ping_monitor" "oci_health_checks_{{ $resourceSuffix }}" {
   provider            = oci.dns_oci_{{ $resourceSuffix }}
   compartment_id      = "{{ .Data.Provider.GetOci.CompartmentOCID }}"
-  display_name        = "health-check-{{ $hostname }}-{{ $clusterID }}"
+  display_name        = "health-check-{{ $hostname }}-{{ $clusterID }}-{{ uniqueFingerPrint }}"
   interval_in_seconds = 30
   protocol = "TCP"
   # Claudie creates a default role for loadbalancers which acts as a healthcheck, that is open on port 65534

--- a/templates/terraformer/oci/dns/dns.tpl
+++ b/templates/terraformer/oci/dns/dns.tpl
@@ -4,8 +4,8 @@
 {{- $resourceSuffix    := printf "%s_%s" $specName $uniqueFingerPrint }}
 {{- $clusterID         := printf "%s-%s" .Data.ClusterName .Data.ClusterHash }}
 {{- $sha256Input       := printf "health-check-%s-%s-%s" $hostname $clusterID $uniqueFingerPrint }}
-{{- $sha256Hash        := sha256sum $sha256Input }}
-{{- $healthCheckName   := printf "hc%s%s" .Data.ClusterHash $sha256Hash }}
+{{- $sha256Hash        := trunc 58 (sha256sum $sha256Input) }}
+{{- $healthCheckName   := printf "hc%s" $sha256Hash }}
 
 provider "oci" {
   tenancy_ocid      = "{{ .Data.Provider.GetOci.TenancyOCID }}"

--- a/templates/terraformer/oci/dns/dns.tpl
+++ b/templates/terraformer/oci/dns/dns.tpl
@@ -3,6 +3,8 @@
 {{- $uniqueFingerPrint := .Fingerprint }}
 {{- $resourceSuffix    := printf "%s_%s" $specName $uniqueFingerPrint }}
 {{- $clusterID         := printf "%s-%s" .Data.ClusterName .Data.ClusterHash }}
+{{- $sha256Input       := printf "health-check-%s-%s-%s" $hostname $clusterID $uniqueFingerPrint }}
+{{- $healthCheckName   := printf "hc%s%s" .Data.ClusterHash sha256sum $sha256Input }}
 
 provider "oci" {
   tenancy_ocid      = "{{ .Data.Provider.GetOci.TenancyOCID }}"
@@ -22,7 +24,7 @@ data "oci_dns_zones" "oci_zone_{{ $resourceSuffix }}" {
 resource "oci_health_checks_ping_monitor" "oci_health_checks_{{ $resourceSuffix }}" {
   provider            = oci.dns_oci_{{ $resourceSuffix }}
   compartment_id      = "{{ .Data.Provider.GetOci.CompartmentOCID }}"
-  display_name        = "health-check-{{ $hostname }}-{{ $clusterID }}-{{ $uniqueFingerPrint }}"
+  display_name        = "{{ $healthCheckName }}"
   interval_in_seconds = 30
   protocol = "TCP"
   # Claudie creates a default role for loadbalancers which acts as a healthcheck, that is open on port 65534

--- a/templates/terraformer/oci/dns/dns.tpl
+++ b/templates/terraformer/oci/dns/dns.tpl
@@ -22,7 +22,7 @@ data "oci_dns_zones" "oci_zone_{{ $resourceSuffix }}" {
 resource "oci_health_checks_ping_monitor" "oci_health_checks_{{ $resourceSuffix }}" {
   provider            = oci.dns_oci_{{ $resourceSuffix }}
   compartment_id      = "{{ .Data.Provider.GetOci.CompartmentOCID }}"
-  display_name        = "health-check-{{ $hostname }}-{{ $clusterID }}-{{ uniqueFingerPrint }}"
+  display_name        = "health-check-{{ $hostname }}-{{ $clusterID }}-{{ $uniqueFingerPrint }}"
   interval_in_seconds = 30
   protocol = "TCP"
   # Claudie creates a default role for loadbalancers which acts as a healthcheck, that is open on port 65534

--- a/templates/terraformer/oci/dns/dns.tpl
+++ b/templates/terraformer/oci/dns/dns.tpl
@@ -22,7 +22,7 @@ data "oci_dns_zones" "oci_zone_{{ $resourceSuffix }}" {
 resource "oci_health_checks_ping_monitor" "oci_health_checks_{{ $resourceSuffix }}" {
   provider            = oci.dns_oci_{{ $resourceSuffix }}
   compartment_id      = "{{ .Data.Provider.GetOci.CompartmentOCID }}"
-  display_name        = "health-check-{{ $hostname }}"
+  display_name        = "health-check-{{ $hostname }}-{{ $clusterID }}"
   interval_in_seconds = 30
   protocol = "TCP"
   # Claudie creates a default role for loadbalancers which acts as a healthcheck, that is open on port 65534

--- a/templates/terraformer/oci/dns/dns.tpl
+++ b/templates/terraformer/oci/dns/dns.tpl
@@ -37,7 +37,7 @@ resource "oci_health_checks_ping_monitor" "oci_health_checks_{{ $resourceSuffix 
 resource "oci_dns_steering_policy" "oci_steering_policy_{{ $resourceSuffix }}" {
   provider                = oci.dns_oci_{{ $resourceSuffix }}
   compartment_id          = "{{ .Data.Provider.GetOci.CompartmentOCID }}"
-  display_name            = "{{ $hostname }}.${data.oci_dns_zones.oci_zone_{{ $resourceSuffix }}.name}"
+  display_name            = "{{ $hostname }}-{{ $clusterID }}-{{ $uniqueFingerPrint }}.${data.oci_dns_zones.oci_zone_{{ $resourceSuffix }}.name}"
   template                = "LOAD_BALANCE"
   ttl                     = 300
   health_check_monitor_id = oci_health_checks_ping_monitor.oci_health_checks_{{ $resourceSuffix }}.id


### PR DESCRIPTION
Added unique names for:
- traffic manager profile name for Azure
- healthchecks name for GCP and OCI
- loadblancer pool name for cloudflare. Note that cloudflare LB name is creaded based on FQDN (no need to change)
(#1822)


AWS creates healtchcheck based on IP.  No need to be changed
