### PR TITLE
feat: Uniformly distribute nodes across zones when zone is not specified

### DIFF
--- a/templates/terraformer/aws/networking/networking.tpl
+++ b/templates/terraformer/aws/networking/networking.tpl
@@ -11,6 +11,12 @@
 
 {{- $resourceSuffix := printf "%s_%s_%s" $region $specName $uniqueFingerPrint }}
 
+# Fetch available availability zones for the region
+data "aws_availability_zones" "available_{{ $resourceSuffix }}" {
+  provider = aws.nodepool_{{ $resourceSuffix }}
+  state    = "available"
+}
+
 {{- $vpcResourceName  := printf "claudie_vpc_%s"  $resourceSuffix }}
 {{- $vpcName          := printf "vpc%s%s-%s"      $clusterHash $uniqueFingerPrint $region }}
 

--- a/templates/terraformer/aws/nodepool/node.tpl
+++ b/templates/terraformer/aws/nodepool/node.tpl
@@ -24,10 +24,9 @@ resource "aws_key_pair" "{{ $keypairResourceName }}" {
   }
 }
 
-    {{- range $node := $nodepool.Nodes }}
+    {{- range $nodeIndex, $node := $nodepool.Nodes }}
 
         {{- $instanceResourceName         := printf "%s_%s" $node.Name $resourceSuffix }}
-        {{- $subnetResourceName           := printf "%s_%s_subnet" $nodepool.Name $resourceSuffix }}
         {{- $securityGroupResourceName    := printf "claudie_sg_%s"   $resourceSuffix }}
         {{- $isWorkerNodeWithDiskAttached := and (not $nodepool.IsControl) (gt $nodepool.Details.StorageDiskSize 0) }}
         {{- $volumeResourceName           := printf "%s_%s_volume" $node.Name $resourceSuffix }}
@@ -35,13 +34,23 @@ resource "aws_key_pair" "{{ $keypairResourceName }}" {
 
         resource "aws_instance" "{{ $instanceResourceName }}" {
           provider          = aws.nodepool_{{ $resourceSuffix }}
+        {{- if $nodepool.Details.Zone }}
           availability_zone = "{{ $nodepool.Details.Zone }}"
+        {{- else }}
+          availability_zone = element(data.aws_availability_zones.available_{{ $resourceSuffix }}.names, {{ $nodeIndex }} % length(data.aws_availability_zones.available_{{ $resourceSuffix }}.names))
+        {{- end }}
           instance_type     = "{{ $nodepool.Details.ServerType }}"
           ami               = "{{ $nodepool.Details.Image }}"
 
           associate_public_ip_address = true
           key_name               = aws_key_pair.{{ $keypairResourceName }}.key_name
+        {{- if $nodepool.Details.Zone }}
+          {{- $subnetResourceName := printf "%s_%s_subnet" $nodepool.Name $resourceSuffix }}
           subnet_id              = aws_subnet.{{ $subnetResourceName }}.id
+        {{- else }}
+          {{- $subnetResourceName := printf "%s_%s_%s_subnet" $nodepool.Name $node.Name $resourceSuffix }}
+          subnet_id              = aws_subnet.{{ $subnetResourceName }}.id
+        {{- end }}
           vpc_security_group_ids = [aws_security_group.{{ $securityGroupResourceName }}.id]
 
           tags = {
@@ -110,7 +119,11 @@ fi
 
         resource "aws_ebs_volume" "{{ $volumeResourceName }}" {
           provider          = aws.nodepool_{{ $resourceSuffix }}
+        {{- if $nodepool.Details.Zone }}
           availability_zone = "{{ $nodepool.Details.Zone }}"
+        {{- else }}
+          availability_zone = element(data.aws_availability_zones.available_{{ $resourceSuffix }}.names, {{ $nodeIndex }} % length(data.aws_availability_zones.available_{{ $resourceSuffix }}.names))
+        {{- end }}
           size              = {{ $nodepool.Details.StorageDiskSize }}
           type              = "gp2"
 

--- a/templates/terraformer/aws/nodepool/node_networking.tpl
+++ b/templates/terraformer/aws/nodepool/node_networking.tpl
@@ -40,18 +40,25 @@ resource "aws_route_table_association" "{{ $associationResourceName }}" {
 
 {{- else }}
 {{- /* Zone is NOT specified - create per-node subnets distributed across availability zones */}}
+{{- /* Calculate newbits dynamically based on node count to support >16 nodes */}}
+{{- $nodeCount := len $nodepool.Nodes }}
+{{- $newbits := 4 }}{{- /* Default: supports up to 16 nodes */}}
+{{- if gt $nodeCount 16 }}{{- $newbits = 5 }}{{- end }}{{- /* 32 nodes */}}
+{{- if gt $nodeCount 32 }}{{- $newbits = 6 }}{{- end }}{{- /* 64 nodes */}}
+{{- if gt $nodeCount 64 }}{{- $newbits = 7 }}{{- end }}{{- /* 128 nodes */}}
+{{- if gt $nodeCount 128 }}{{- $newbits = 8 }}{{- end }}{{- /* 256 nodes */}}
 
     {{- range $nodeIndex, $node := $nodepool.Nodes }}
 
         {{- $subnetResourceName        := printf "%s_%s_%s_subnet" $nodepool.Name $node.Name $resourceSuffix }}
         {{- $subnetName                := printf "snt-%s-%s-%s-%s" $clusterHash $region $nodepool.Name $node.Name }}
         {{- /* Calculate subnet CIDR: base CIDR with node-specific offset */}}
-        {{- /* Using /24 subnets within the nodepool's CIDR range */}}
+        {{- /* newbits is calculated dynamically based on node count */}}
 
 resource "aws_subnet" "{{ $subnetResourceName }}" {
   provider                = aws.nodepool_{{ $resourceSuffix }}
   vpc_id                  = aws_vpc.{{ $vpcResourceName }}.id
-  cidr_block              = cidrsubnet("{{ $nodepool.Details.Cidr }}", 4, {{ $nodeIndex }})
+  cidr_block              = cidrsubnet("{{ $nodepool.Details.Cidr }}", {{ $newbits }}, {{ $nodeIndex }})
   map_public_ip_on_launch = true
   availability_zone       = element(data.aws_availability_zones.available_{{ $resourceSuffix }}.names, {{ $nodeIndex }} % length(data.aws_availability_zones.available_{{ $resourceSuffix }}.names))
 

--- a/templates/terraformer/aws/nodepool/node_networking.tpl
+++ b/templates/terraformer/aws/nodepool/node_networking.tpl
@@ -7,11 +7,15 @@
 {{- $region                     := $nodepool.Details.Region }}
 {{- $specName                   := $nodepool.Details.Provider.SpecName }}
 {{- $resourceSuffix             := printf "%s_%s_%s" $region $specName $uniqueFingerPrint }}
+{{- $vpcResourceName            := printf "claudie_vpc_%s"   $resourceSuffix }}
+{{- $routeTableResourceName     := printf "claudie_route_table_%s"   $resourceSuffix }}
+
+{{- if $nodepool.Details.Zone }}
+{{- /* Zone is specified - create a single subnet for the nodepool */}}
 
 {{- $subnetResourceName  := printf "%s_%s_subnet" $nodepool.Name $resourceSuffix }}
 {{- $subnetName          := printf "snt-%s-%s-%s" $clusterHash $region $nodepool.Name }}
 {{- $subnetCIDR          := $nodepool.Details.Cidr }}
-{{- $vpcResourceName     := printf "claudie_vpc_%s"   $resourceSuffix }}
 
 resource "aws_subnet" "{{ $subnetResourceName }}" {
   provider                = aws.nodepool_{{ $resourceSuffix }}
@@ -27,11 +31,44 @@ resource "aws_subnet" "{{ $subnetResourceName }}" {
 }
 
 {{- $associationResourceName  := printf "%s_%s_rta" $nodepool.Name $resourceSuffix }}
-{{- $routeTableResourceName   := printf "claudie_route_table_%s"   $resourceSuffix }}
 
 resource "aws_route_table_association" "{{ $associationResourceName }}" {
   provider       = aws.nodepool_{{ $resourceSuffix }}
   subnet_id      = aws_subnet.{{ $subnetResourceName }}.id
   route_table_id = aws_route_table.{{ $routeTableResourceName }}.id
 }
+
+{{- else }}
+{{- /* Zone is NOT specified - create per-node subnets distributed across availability zones */}}
+
+    {{- range $nodeIndex, $node := $nodepool.Nodes }}
+
+        {{- $subnetResourceName        := printf "%s_%s_%s_subnet" $nodepool.Name $node.Name $resourceSuffix }}
+        {{- $subnetName                := printf "snt-%s-%s-%s-%s" $clusterHash $region $nodepool.Name $node.Name }}
+        {{- /* Calculate subnet CIDR: base CIDR with node-specific offset */}}
+        {{- /* Using /24 subnets within the nodepool's CIDR range */}}
+
+resource "aws_subnet" "{{ $subnetResourceName }}" {
+  provider                = aws.nodepool_{{ $resourceSuffix }}
+  vpc_id                  = aws_vpc.{{ $vpcResourceName }}.id
+  cidr_block              = cidrsubnet("{{ $nodepool.Details.Cidr }}", 4, {{ $nodeIndex }})
+  map_public_ip_on_launch = true
+  availability_zone       = element(data.aws_availability_zones.available_{{ $resourceSuffix }}.names, {{ $nodeIndex }} % length(data.aws_availability_zones.available_{{ $resourceSuffix }}.names))
+
+  tags = {
+    Name            = "{{ $subnetName }}"
+    Claudie-cluster = "{{ $clusterName }}-{{ $clusterHash }}"
+  }
+}
+
+        {{- $associationResourceName := printf "%s_%s_%s_rta" $nodepool.Name $node.Name $resourceSuffix }}
+
+resource "aws_route_table_association" "{{ $associationResourceName }}" {
+  provider       = aws.nodepool_{{ $resourceSuffix }}
+  subnet_id      = aws_subnet.{{ $subnetResourceName }}.id
+  route_table_id = aws_route_table.{{ $routeTableResourceName }}.id
+}
+
+    {{- end }}
+{{- end }}
 {{- end }}

--- a/templates/terraformer/azure/networking/networking.tpl
+++ b/templates/terraformer/azure/networking/networking.tpl
@@ -14,6 +14,8 @@ locals {
     "udp"    = "Udp"
     "icmp"   = "Icmp"
   }
+  # Available zones for uniform distribution when zone is not specified
+  azure_zones_{{ $specName }}_{{ $uniqueFingerPrint }} = ["1", "2", "3"]
 }
 
 {{- $basePriority  := printf "base_priority_%s_%s" $specName $uniqueFingerPrint }}

--- a/templates/terraformer/azure/networking/networking.tpl
+++ b/templates/terraformer/azure/networking/networking.tpl
@@ -14,8 +14,6 @@ locals {
     "udp"    = "Udp"
     "icmp"   = "Icmp"
   }
-  # Available zones for uniform distribution when zone is not specified
-  azure_zones_{{ $specName }}_{{ $uniqueFingerPrint }} = ["1", "2", "3"]
 }
 
 {{- $basePriority  := printf "base_priority_%s_%s" $specName $uniqueFingerPrint }}
@@ -29,6 +27,17 @@ variable "{{ $basePriority }}" {
 {{- $sanitisedRegion := replaceAll $region " " "_"}}
 {{- $resourceSuffix := printf "%s_%s_%s" $sanitisedRegion $specName $uniqueFingerPrint }}
 
+# Fetch available zones for this region dynamically
+data "azurerm_location" "location_{{ $resourceSuffix }}" {
+  provider = azurerm.nodepool_{{ $resourceSuffix }}
+  location = "{{ $region }}"
+}
+
+locals {
+  # Extract logical zones from zone_mappings for uniform distribution when zone is not specified.
+  # Returns empty list if region doesn't support AZs - in that case, zone parameter will be omitted.
+  azure_zones_{{ $resourceSuffix }} = [for zm in data.azurerm_location.location_{{ $resourceSuffix }}.zone_mappings : zm.logical_zone]
+}
 
 {{- $resourceGroupResourceName  := printf "rg_%s"     $resourceSuffix }}
 {{- $resourceGroupName          := printf "rg%s%s-%s" $clusterHash $uniqueFingerPrint $sanitisedRegion }}

--- a/templates/terraformer/azure/nodepool/node.tpl
+++ b/templates/terraformer/azure/nodepool/node.tpl
@@ -32,7 +32,8 @@
         {{- if $nodepool.Details.Zone }}
           zone                  = "{{$nodepool.Details.Zone}}"
         {{- else }}
-          zone                  = element(local.azure_zones_{{ $specName }}_{{ $uniqueFingerPrint }}, {{ $nodeIndex }} % length(local.azure_zones_{{ $specName }}_{{ $uniqueFingerPrint }}))
+          # Zone is only set if the region supports availability zones
+          zone                  = length(local.azure_zones_{{ $resourceSuffix }}) > 0 ? element(local.azure_zones_{{ $resourceSuffix }}, {{ $nodeIndex }} % length(local.azure_zones_{{ $resourceSuffix }})) : null
         {{- end }}
 
           source_image_reference {
@@ -171,7 +172,8 @@ PROT
         {{- if $nodepool.Details.Zone }}
           zone                 = {{ $nodepool.Details.Zone }}
         {{- else }}
-          zone                 = element(local.azure_zones_{{ $specName }}_{{ $uniqueFingerPrint }}, {{ $nodeIndex }} % length(local.azure_zones_{{ $specName }}_{{ $uniqueFingerPrint }}))
+          # Zone is only set if the region supports availability zones
+          zone                 = length(local.azure_zones_{{ $resourceSuffix }}) > 0 ? element(local.azure_zones_{{ $resourceSuffix }}, {{ $nodeIndex }} % length(local.azure_zones_{{ $resourceSuffix }})) : null
         {{- end }}
           resource_group_name  = azurerm_resource_group.{{ $resourceGroupResourceName }}.name
           storage_account_type = "StandardSSD_LRS"

--- a/templates/terraformer/azure/nodepool/node.tpl
+++ b/templates/terraformer/azure/nodepool/node.tpl
@@ -1,16 +1,17 @@
 {{- $clusterName           := .Data.ClusterData.ClusterName}}
 {{- $clusterHash           := .Data.ClusterData.ClusterHash}}
 {{- $uniqueFingerPrint     := .Fingerprint }}
+{{- $specName              := (index .Data.NodePools 0).Details.Provider.SpecName }}
 {{- $isKubernetesCluster   := eq .Data.ClusterData.ClusterType "K8s" }}
 {{- $isLoadbalancerCluster := eq .Data.ClusterData.ClusterType "LB" }}
 
 {{- range $i, $nodepool := .Data.NodePools }}
 
 {{- $sanitisedRegion := replaceAll $nodepool.Details.Region " " "_"}}
-{{- $specName       := $nodepool.Details.Provider.SpecName }}
-{{- $resourceSuffix := printf "%s_%s_%s" $sanitisedRegion $specName $uniqueFingerPrint }}
+{{- $nodepoolSpecName       := $nodepool.Details.Provider.SpecName }}
+{{- $resourceSuffix := printf "%s_%s_%s" $sanitisedRegion $nodepoolSpecName $uniqueFingerPrint }}
 
-    {{- range $node := $nodepool.Nodes }}
+    {{- range $nodeIndex, $node := $nodepool.Nodes }}
 
         {{- $virtualMachineResourceName   := printf "%s_%s" $node.Name $resourceSuffix }}
         {{- $resourceGroupResourceName    := printf "rg_%s"   $resourceSuffix }}
@@ -28,7 +29,11 @@
           resource_group_name   = azurerm_resource_group.{{ $resourceGroupResourceName }}.name
           network_interface_ids = [azurerm_network_interface.{{ $networkInterfaceResourceName }}.id]
           size                  = "{{$nodepool.Details.ServerType}}"
+        {{- if $nodepool.Details.Zone }}
           zone                  = "{{$nodepool.Details.Zone}}"
+        {{- else }}
+          zone                  = element(local.azure_zones_{{ $specName }}_{{ $uniqueFingerPrint }}, {{ $nodeIndex }} % length(local.azure_zones_{{ $specName }}_{{ $uniqueFingerPrint }}))
+        {{- end }}
 
           source_image_reference {
             publisher = split(":", "{{ $nodepool.Details.Image }}")[0]
@@ -163,7 +168,11 @@ PROT
           provider             = azurerm.nodepool_{{ $resourceSuffix }}
           name                 = "{{ $vmDiskName }}"
           location             = "{{ $nodepool.Details.Region }}"
+        {{- if $nodepool.Details.Zone }}
           zone                 = {{ $nodepool.Details.Zone }}
+        {{- else }}
+          zone                 = element(local.azure_zones_{{ $specName }}_{{ $uniqueFingerPrint }}, {{ $nodeIndex }} % length(local.azure_zones_{{ $specName }}_{{ $uniqueFingerPrint }}))
+        {{- end }}
           resource_group_name  = azurerm_resource_group.{{ $resourceGroupResourceName }}.name
           storage_account_type = "StandardSSD_LRS"
           create_option        = "Empty"
@@ -189,7 +198,7 @@ PROT
 
     {{- end }}
 
-output "{{ $nodepool.Name }}_{{ $specName }}_{{ $uniqueFingerPrint }}" {
+output "{{ $nodepool.Name }}_{{ $nodepoolSpecName }}_{{ $uniqueFingerPrint }}" {
   value = {
     {{- range $node := $nodepool.Nodes }}
         {{- $virtualMachineResourceName   := printf "%s_%s" $node.Name $resourceSuffix }}

--- a/templates/terraformer/gcp/networking/networking.tpl
+++ b/templates/terraformer/gcp/networking/networking.tpl
@@ -11,6 +11,13 @@
 
 {{- $resourceSuffix := printf "%s_%s_%s" $region $specName $uniqueFingerPrint }}
 
+# Fetch available zones for the region
+data "google_compute_zones" "available_{{ $resourceSuffix }}" {
+  provider = google.nodepool_{{ $resourceSuffix }}
+  region   = "{{ $region }}"
+  status   = "UP"
+}
+
 {{- if $isKubernetesCluster }}
     {{- $varStorageDiskName  := printf "gcp_storage_disk_name_%s" $resourceSuffix }}
     variable "{{ $varStorageDiskName}}" {

--- a/templates/terraformer/gcp/nodepool/node.tpl
+++ b/templates/terraformer/gcp/nodepool/node.tpl
@@ -24,6 +24,13 @@
           zone                      = "{{ $nodepool.Details.Zone }}"
         {{- else }}
           zone                      = element(data.google_compute_zones.available_{{ $resourceSuffix }}.names, {{ $nodeIndex }} % length(data.google_compute_zones.available_{{ $resourceSuffix }}.names))
+
+          lifecycle {
+            precondition {
+              condition     = length(data.google_compute_zones.available_{{ $resourceSuffix }}.names) > 0
+              error_message = "No available zones found for region {{ $region }}. Check GCP permissions or region configuration."
+            }
+          }
         {{- end }}
           name                      = "{{ $node.Name }}"
           machine_type              = "{{ $nodepool.Details.ServerType }}"
@@ -114,6 +121,13 @@ EOF
               zone     = "{{ $nodepool.Details.Zone }}"
             {{- else }}
               zone     = element(data.google_compute_zones.available_{{ $resourceSuffix }}.names, {{ $nodeIndex }} % length(data.google_compute_zones.available_{{ $resourceSuffix }}.names))
+
+              lifecycle {
+                precondition {
+                  condition     = length(data.google_compute_zones.available_{{ $resourceSuffix }}.names) > 0
+                  error_message = "No available zones found for region {{ $region }}. Check GCP permissions or region configuration."
+                }
+              }
             {{- end }}
               size     = {{ $nodepool.Details.StorageDiskSize }}
 
@@ -131,6 +145,13 @@ EOF
               zone        = "{{ $nodepool.Details.Zone }}"
             {{- else }}
               zone        = element(data.google_compute_zones.available_{{ $resourceSuffix }}.names, {{ $nodeIndex }} % length(data.google_compute_zones.available_{{ $resourceSuffix }}.names))
+
+              lifecycle {
+                precondition {
+                  condition     = length(data.google_compute_zones.available_{{ $resourceSuffix }}.names) > 0
+                  error_message = "No available zones found for region {{ $region }}. Check GCP permissions or region configuration."
+                }
+              }
             {{- end }}
               device_name = var.{{ $varStorageDiskName }}
             }

--- a/templates/terraformer/gcp/nodepool/node.tpl
+++ b/templates/terraformer/gcp/nodepool/node.tpl
@@ -11,7 +11,7 @@
 {{- $specName       := $nodepool.Details.Provider.SpecName }}
 {{- $resourceSuffix := printf "%s_%s_%s" $region $specName $uniqueFingerPrint }}
 
-    {{- range $node := $nodepool.Nodes }}
+    {{- range $nodeIndex, $node := $nodepool.Nodes }}
 
         {{- $computeInstanceResourceName  := printf "%s_%s" $node.Name $resourceSuffix }}
         {{- $computeSubnetResourceName    := printf "%s_%s_subnet" $nodepool.Name $resourceSuffix }}
@@ -20,7 +20,11 @@
 
         resource "google_compute_instance" "{{ $computeInstanceResourceName}}" {
           provider                  = google.nodepool_{{ $resourceSuffix }}
+        {{- if $nodepool.Details.Zone }}
           zone                      = "{{ $nodepool.Details.Zone }}"
+        {{- else }}
+          zone                      = element(data.google_compute_zones.available_{{ $resourceSuffix }}.names, {{ $nodeIndex }} % length(data.google_compute_zones.available_{{ $resourceSuffix }}.names))
+        {{- end }}
           name                      = "{{ $node.Name }}"
           machine_type              = "{{ $nodepool.Details.ServerType }}"
           description   = "Managed by Claudie for cluster {{ $clusterName }}-{{ $clusterHash }}"
@@ -106,7 +110,11 @@ EOF
               # suffix 'd' as otherwise the creation of the VM instance and attachment of the disk will fail, if having the same name as the node.
               name     = "{{ $computeDiskName }}"
               type     = "pd-ssd"
+            {{- if $nodepool.Details.Zone }}
               zone     = "{{ $nodepool.Details.Zone }}"
+            {{- else }}
+              zone     = element(data.google_compute_zones.available_{{ $resourceSuffix }}.names, {{ $nodeIndex }} % length(data.google_compute_zones.available_{{ $resourceSuffix }}.names))
+            {{- end }}
               size     = {{ $nodepool.Details.StorageDiskSize }}
 
               labels = {
@@ -119,7 +127,11 @@ EOF
               provider    = google.nodepool_{{ $resourceSuffix }}
               disk        = google_compute_disk.{{ $computeDiskResourceName }}.id
               instance    = google_compute_instance.{{ $computeInstanceResourceName }}.id
+            {{- if $nodepool.Details.Zone }}
               zone        = "{{ $nodepool.Details.Zone }}"
+            {{- else }}
+              zone        = element(data.google_compute_zones.available_{{ $resourceSuffix }}.names, {{ $nodeIndex }} % length(data.google_compute_zones.available_{{ $resourceSuffix }}.names))
+            {{- end }}
               device_name = var.{{ $varStorageDiskName }}
             }
             {{- end }}

--- a/templates/terraformer/oci/networking/networking.tpl
+++ b/templates/terraformer/oci/networking/networking.tpl
@@ -19,6 +19,13 @@ locals {
 {{- range $_, $region := .Data.Regions }}
 
 {{- $resourceSuffix := printf "%s_%s_%s" $region $specName $uniqueFingerPrint }}
+{{- $varCompartmentID  := printf "default_compartment_id_%s" $resourceSuffix }}
+
+# Fetch available availability domains for the region
+data "oci_identity_availability_domains" "available_{{ $resourceSuffix }}" {
+  provider       = oci.nodepool_{{ $resourceSuffix }}
+  compartment_id = var.{{ $varCompartmentID }}
+}
 
 {{- if $isKubernetesCluster }}
     {{- $varStorageDiskName  := printf "oci_storage_disk_name_%s" $resourceSuffix }}

--- a/templates/terraformer/oci/networking/networking.tpl
+++ b/templates/terraformer/oci/networking/networking.tpl
@@ -22,9 +22,11 @@ locals {
 {{- $varCompartmentID  := printf "default_compartment_id_%s" $resourceSuffix }}
 
 # Fetch available availability domains for the region
+# Note: Availability domains must be queried using the tenancy OCID (root compartment),
+# not a sub-compartment OCID, as ADs are tenancy-level resources.
 data "oci_identity_availability_domains" "available_{{ $resourceSuffix }}" {
   provider       = oci.nodepool_{{ $resourceSuffix }}
-  compartment_id = var.{{ $varCompartmentID }}
+  compartment_id = "{{ $.Data.Provider.GetOci.TenancyOCID }}"
 }
 
 {{- if $isKubernetesCluster }}

--- a/templates/terraformer/oci/nodepool/node.tpl
+++ b/templates/terraformer/oci/nodepool/node.tpl
@@ -11,7 +11,7 @@
 {{- $specName       := $nodepool.Details.Provider.SpecName }}
 {{- $resourceSuffix := printf "%s_%s_%s" $region $specName $uniqueFingerPrint }}
 
-    {{- range $node := $nodepool.Nodes }}
+    {{- range $nodeIndex, $node := $nodepool.Nodes }}
 
         {{- $coreInstanceResourceName     := printf "%s_%s" $node.Name $resourceSuffix }}
         {{- $coreSubnetResourceName       := printf "%s_%s_subnet" $nodepool.Name $resourceSuffix }}
@@ -22,7 +22,11 @@
         resource "oci_core_instance" "{{ $coreInstanceResourceName }}" {
           provider            = oci.nodepool_{{ $resourceSuffix }}
           compartment_id      = var.{{ $varCompartmentID }}
+        {{- if $nodepool.Details.Zone }}
           availability_domain = "{{ $nodepool.Details.Zone }}"
+        {{- else }}
+          availability_domain = element(data.oci_identity_availability_domains.available_{{ $resourceSuffix }}.availability_domains[*].name, {{ $nodeIndex }} % length(data.oci_identity_availability_domains.available_{{ $resourceSuffix }}.availability_domains))
+        {{- end }}
           shape               = "{{ $nodepool.Details.ServerType }}"
           display_name        = "{{ $node.Name }}"
 
@@ -139,7 +143,11 @@
             resource "oci_core_volume" "{{ $coreVolumeResourceName }}" {
               provider            = oci.nodepool_{{ $resourceSuffix }}
               compartment_id      = var.{{ $varCompartmentID }}
+            {{- if $nodepool.Details.Zone }}
               availability_domain = "{{ $nodepool.Details.Zone }}"
+            {{- else }}
+              availability_domain = element(data.oci_identity_availability_domains.available_{{ $resourceSuffix }}.availability_domains[*].name, {{ $nodeIndex }} % length(data.oci_identity_availability_domains.available_{{ $resourceSuffix }}.availability_domains))
+            {{- end }}
               size_in_gbs         = "{{ $nodepool.Details.StorageDiskSize }}"
               display_name        = "{{ $coreVolumeName }}"
               vpus_per_gb         = 10

--- a/templates/terraformer/oci/nodepool/node_networking.tpl
+++ b/templates/terraformer/oci/nodepool/node_networking.tpl
@@ -7,13 +7,12 @@
 {{- $region                     := $nodepool.Details.Region }}
 {{- $specName                   := $nodepool.Details.Provider.SpecName }}
 {{- $resourceSuffix             := printf "%s_%s_%s" $region $specName $uniqueFingerPrint }}
-
+{{- $coreVCNResourceName        := printf "claudie_vcn_%s"   $resourceSuffix }}
+{{- $varCompartmentID           := printf "default_compartment_id_%s" $resourceSuffix }}
 
 {{- $coreSubnetResourceName  := printf "%s_%s_subnet" $nodepool.Name $resourceSuffix }}
 {{- $coreSubnetName          := printf "snt-%s-%s-%s" $clusterHash $region $nodepool.Name }}
 {{- $coreSubnetCIDR          := $nodepool.Details.Cidr }}
-{{- $coreVCNResourceName     := printf "claudie_vcn_%s"   $resourceSuffix }}
-{{- $varCompartmentID        := printf "default_compartment_id_%s" $resourceSuffix }}
 
 resource "oci_core_subnet" "{{ $coreSubnetResourceName }}" {
   provider            = oci.nodepool_{{ $resourceSuffix }}
@@ -24,7 +23,10 @@ resource "oci_core_subnet" "{{ $coreSubnetResourceName }}" {
   security_list_ids   = [oci_core_vcn.{{ $coreVCNResourceName }}.default_security_list_id]
   route_table_id      = oci_core_vcn.{{ $coreVCNResourceName }}.default_route_table_id
   dhcp_options_id     = oci_core_vcn.{{ $coreVCNResourceName }}.default_dhcp_options_id
+{{- if $nodepool.Details.Zone }}
   availability_domain = "{{ $nodepool.Details.Zone }}"
+{{- end }}
+{{- /* When zone is not specified, omit availability_domain to create a regional subnet */}}
 
   freeform_tags = {
     "Managed-by"      = "Claudie"


### PR DESCRIPTION
## Summary
- When `providerSpec.zone` is not specified in the InputManifest, nodes are now automatically distributed across available zones using `node_index % zone_count`
- Implemented for AWS, Azure, GCP, and OCI providers (Hetzner doesn't suppor zones in regions yet)
- When zone IS specified, existing behavior is preserved

## Changes per provider
- **AWS**: Added `aws_availability_zones` data source, per-node subnets for zone distribution (AWS subnets are zone-specific)
- **Azure**: Use zones `["1", "2", "3"]` for distribution
- **GCP**: Added `google_compute_zones` data source
- **OCI**: Added `oci_identity_availability_domains` data source, use regional subnets when zone not specified

## Test plan
- [x] Tested on AWS provider
- [x] Tested on Azure provider
- [x] Tested on GCP provider
- [x] Tested on OCI provider

Closes: berops/claudie#1629

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Enhanced availability zone discovery per region for AWS, Azure, GCP and OCI.
  * Automatic round‑robin zone distribution when a zone isn’t specified.
  * Per-node index‑based zone assignment for instances, disks/volumes, and attached storage.
  * Conditional per-node subnet creation and route associations when zones are unspecified; single‑zone behavior preserved when provided.
  * Resource naming/outputs adjusted to reflect per-nodepool spec names for clearer mapping.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->