### PR TITLE
feat: Uniformly distribute nodes across zones when zone is not specified

### DIFF
--- a/templates/terraformer/aws/networking/networking.tpl
+++ b/templates/terraformer/aws/networking/networking.tpl
@@ -11,6 +11,12 @@
 
 {{- $resourceSuffix := printf "%s_%s_%s" $region $specName $uniqueFingerPrint }}
 
+# Fetch available availability zones for this region
+data "aws_availability_zones" "available_{{ $resourceSuffix }}" {
+  provider = aws.nodepool_{{ $resourceSuffix }}
+  state    = "available"
+}
+
 {{- $vpcResourceName  := printf "claudie_vpc_%s"  $resourceSuffix }}
 {{- $vpcName          := printf "vpc%s%s-%s"      $clusterHash $uniqueFingerPrint $region }}
 

--- a/templates/terraformer/aws/nodepool/node.tpl
+++ b/templates/terraformer/aws/nodepool/node.tpl
@@ -24,10 +24,16 @@ resource "aws_key_pair" "{{ $keypairResourceName }}" {
   }
 }
 
-    {{- range $node := $nodepool.Nodes }}
+    {{- range $nodeIndex, $node := $nodepool.Nodes }}
 
         {{- $instanceResourceName         := printf "%s_%s" $node.Name $resourceSuffix }}
-        {{- $subnetResourceName           := printf "%s_%s_subnet" $nodepool.Name $resourceSuffix }}
+        {{- /* Subnet name depends on whether zone is specified */}}
+        {{- $subnetResourceName           := "" }}
+        {{- if $nodepool.Details.Zone }}
+            {{- $subnetResourceName = printf "%s_%s_subnet" $nodepool.Name $resourceSuffix }}
+        {{- else }}
+            {{- $subnetResourceName = printf "%s_%s_%s_subnet" $nodepool.Name $node.Name $resourceSuffix }}
+        {{- end }}
         {{- $securityGroupResourceName    := printf "claudie_sg_%s"   $resourceSuffix }}
         {{- $isWorkerNodeWithDiskAttached := and (not $nodepool.IsControl) (gt $nodepool.Details.StorageDiskSize 0) }}
         {{- $volumeResourceName           := printf "%s_%s_volume" $node.Name $resourceSuffix }}
@@ -35,7 +41,11 @@ resource "aws_key_pair" "{{ $keypairResourceName }}" {
 
         resource "aws_instance" "{{ $instanceResourceName }}" {
           provider          = aws.nodepool_{{ $resourceSuffix }}
+        {{- if $nodepool.Details.Zone }}
           availability_zone = "{{ $nodepool.Details.Zone }}"
+        {{- else }}
+          availability_zone = element(data.aws_availability_zones.available_{{ $resourceSuffix }}.names, {{ $nodeIndex }} % length(data.aws_availability_zones.available_{{ $resourceSuffix }}.names))
+        {{- end }}
           instance_type     = "{{ $nodepool.Details.ServerType }}"
           ami               = "{{ $nodepool.Details.Image }}"
 
@@ -132,7 +142,11 @@ fi
 
         resource "aws_ebs_volume" "{{ $volumeResourceName }}" {
           provider          = aws.nodepool_{{ $resourceSuffix }}
+        {{- if $nodepool.Details.Zone }}
           availability_zone = "{{ $nodepool.Details.Zone }}"
+        {{- else }}
+          availability_zone = element(data.aws_availability_zones.available_{{ $resourceSuffix }}.names, {{ $nodeIndex }} % length(data.aws_availability_zones.available_{{ $resourceSuffix }}.names))
+        {{- end }}
           size              = {{ $nodepool.Details.StorageDiskSize }}
           type              = "gp2"
 

--- a/templates/terraformer/aws/nodepool/node_networking.tpl
+++ b/templates/terraformer/aws/nodepool/node_networking.tpl
@@ -7,11 +7,14 @@
 {{- $region                     := $nodepool.Details.Region }}
 {{- $specName                   := $nodepool.Details.Provider.SpecName }}
 {{- $resourceSuffix             := printf "%s_%s_%s" $region $specName $uniqueFingerPrint }}
+{{- $vpcResourceName            := printf "claudie_vpc_%s"   $resourceSuffix }}
+{{- $routeTableResourceName     := printf "claudie_route_table_%s"   $resourceSuffix }}
 
+{{- if $nodepool.Details.Zone }}
+{{- /* Zone is specified - use existing single subnet logic */}}
 {{- $subnetResourceName  := printf "%s_%s_subnet" $nodepool.Name $resourceSuffix }}
 {{- $subnetName          := printf "snt-%s-%s-%s" $clusterHash $region $nodepool.Name }}
 {{- $subnetCIDR          := $nodepool.Details.Cidr }}
-{{- $vpcResourceName     := printf "claudie_vpc_%s"   $resourceSuffix }}
 
 resource "aws_subnet" "{{ $subnetResourceName }}" {
   provider                = aws.nodepool_{{ $resourceSuffix }}
@@ -27,11 +30,51 @@ resource "aws_subnet" "{{ $subnetResourceName }}" {
 }
 
 {{- $associationResourceName  := printf "%s_%s_rta" $nodepool.Name $resourceSuffix }}
-{{- $routeTableResourceName   := printf "claudie_route_table_%s"   $resourceSuffix }}
 
 resource "aws_route_table_association" "{{ $associationResourceName }}" {
   provider       = aws.nodepool_{{ $resourceSuffix }}
   subnet_id      = aws_subnet.{{ $subnetResourceName }}.id
   route_table_id = aws_route_table.{{ $routeTableResourceName }}.id
 }
+
+{{- else }}
+{{- /* Zone is NOT specified - create per-node subnets distributed across availability zones */}}
+{{- /* Calculate newbits dynamically based on node count to support >16 nodes */}}
+{{- $nodeCount := len $nodepool.Nodes }}
+{{- $newbits := 4 }}{{- /* Default: supports up to 16 nodes */}}
+{{- if gt $nodeCount 16 }}{{- $newbits = 5 }}{{- end }}{{- /* 32 nodes */}}
+{{- if gt $nodeCount 32 }}{{- $newbits = 6 }}{{- end }}{{- /* 64 nodes */}}
+{{- if gt $nodeCount 64 }}{{- $newbits = 7 }}{{- end }}{{- /* 128 nodes */}}
+{{- if gt $nodeCount 128 }}{{- $newbits = 8 }}{{- end }}{{- /* 256 nodes */}}
+
+    {{- range $nodeIndex, $node := $nodepool.Nodes }}
+
+        {{- $subnetResourceName        := printf "%s_%s_%s_subnet" $nodepool.Name $node.Name $resourceSuffix }}
+        {{- $subnetName                := printf "snt-%s-%s-%s-%s" $clusterHash $region $nodepool.Name $node.Name }}
+        {{- /* Calculate subnet CIDR: base CIDR with node-specific offset */}}
+        {{- /* newbits is calculated dynamically based on node count */}}
+
+resource "aws_subnet" "{{ $subnetResourceName }}" {
+  provider                = aws.nodepool_{{ $resourceSuffix }}
+  vpc_id                  = aws_vpc.{{ $vpcResourceName }}.id
+  cidr_block              = cidrsubnet("{{ $nodepool.Details.Cidr }}", {{ $newbits }}, {{ $nodeIndex }})
+  map_public_ip_on_launch = true
+  availability_zone       = element(data.aws_availability_zones.available_{{ $resourceSuffix }}.names, {{ $nodeIndex }} % length(data.aws_availability_zones.available_{{ $resourceSuffix }}.names))
+
+  tags = {
+    Name            = "{{ $subnetName }}"
+    Claudie-cluster = "{{ $clusterName }}-{{ $clusterHash }}"
+  }
+}
+
+        {{- $associationResourceName  := printf "%s_%s_%s_rta" $nodepool.Name $node.Name $resourceSuffix }}
+
+resource "aws_route_table_association" "{{ $associationResourceName }}" {
+  provider       = aws.nodepool_{{ $resourceSuffix }}
+  subnet_id      = aws_subnet.{{ $subnetResourceName }}.id
+  route_table_id = aws_route_table.{{ $routeTableResourceName }}.id
+}
+
+    {{- end }}
+{{- end }}
 {{- end }}

--- a/templates/terraformer/azure/networking/networking.tpl
+++ b/templates/terraformer/azure/networking/networking.tpl
@@ -27,6 +27,17 @@ variable "{{ $basePriority }}" {
 {{- $sanitisedRegion := replaceAll $region " " "_"}}
 {{- $resourceSuffix := printf "%s_%s_%s" $sanitisedRegion $specName $uniqueFingerPrint }}
 
+# Fetch available zones for this region dynamically
+data "azurerm_location" "location_{{ $resourceSuffix }}" {
+  provider = azurerm.nodepool_{{ $resourceSuffix }}
+  location = "{{ $region }}"
+}
+
+locals {
+  # Extract logical zones from zone_mappings for uniform distribution when zone is not specified.
+  # Returns empty list if region doesn't support AZs - in that case, zone parameter will be omitted.
+  azure_zones_{{ $resourceSuffix }} = [for zm in data.azurerm_location.location_{{ $resourceSuffix }}.zone_mappings : zm.logical_zone]
+}
 
 {{- $resourceGroupResourceName  := printf "rg_%s"     $resourceSuffix }}
 {{- $resourceGroupName          := printf "rg%s%s-%s" $clusterHash $uniqueFingerPrint $sanitisedRegion }}

--- a/templates/terraformer/azure/nodepool/node.tpl
+++ b/templates/terraformer/azure/nodepool/node.tpl
@@ -7,10 +7,10 @@
 {{- range $i, $nodepool := .Data.NodePools }}
 
 {{- $sanitisedRegion := replaceAll $nodepool.Details.Region " " "_"}}
-{{- $specName       := $nodepool.Details.Provider.SpecName }}
-{{- $resourceSuffix := printf "%s_%s_%s" $sanitisedRegion $specName $uniqueFingerPrint }}
+{{- $nodepoolSpecName       := $nodepool.Details.Provider.SpecName }}
+{{- $resourceSuffix := printf "%s_%s_%s" $sanitisedRegion $nodepoolSpecName $uniqueFingerPrint }}
 
-    {{- range $node := $nodepool.Nodes }}
+    {{- range $nodeIndex, $node := $nodepool.Nodes }}
 
         {{- $virtualMachineResourceName   := printf "%s_%s" $node.Name $resourceSuffix }}
         {{- $resourceGroupResourceName    := printf "rg_%s"   $resourceSuffix }}
@@ -28,7 +28,12 @@
           resource_group_name   = azurerm_resource_group.{{ $resourceGroupResourceName }}.name
           network_interface_ids = [azurerm_network_interface.{{ $networkInterfaceResourceName }}.id]
           size                  = "{{$nodepool.Details.ServerType}}"
+        {{- if $nodepool.Details.Zone }}
           zone                  = "{{$nodepool.Details.Zone}}"
+        {{- else }}
+          # Zone is only set if the region supports availability zones
+          zone                  = length(local.azure_zones_{{ $resourceSuffix }}) > 0 ? element(local.azure_zones_{{ $resourceSuffix }}, {{ $nodeIndex }} % length(local.azure_zones_{{ $resourceSuffix }})) : null
+        {{- end }}
 
           source_image_reference {
             publisher = split(":", "{{ $nodepool.Details.Image }}")[0]
@@ -163,7 +168,12 @@ PROT
           provider             = azurerm.nodepool_{{ $resourceSuffix }}
           name                 = "{{ $vmDiskName }}"
           location             = "{{ $nodepool.Details.Region }}"
+        {{- if $nodepool.Details.Zone }}
           zone                 = {{ $nodepool.Details.Zone }}
+        {{- else }}
+          # Zone is only set if the region supports availability zones
+          zone                 = length(local.azure_zones_{{ $resourceSuffix }}) > 0 ? element(local.azure_zones_{{ $resourceSuffix }}, {{ $nodeIndex }} % length(local.azure_zones_{{ $resourceSuffix }})) : null
+        {{- end }}
           resource_group_name  = azurerm_resource_group.{{ $resourceGroupResourceName }}.name
           storage_account_type = "StandardSSD_LRS"
           create_option        = "Empty"
@@ -189,7 +199,7 @@ PROT
 
     {{- end }}
 
-output "{{ $nodepool.Name }}_{{ $specName }}_{{ $uniqueFingerPrint }}" {
+output "{{ $nodepool.Name }}_{{ $nodepoolSpecName }}_{{ $uniqueFingerPrint }}" {
   value = {
     {{- range $node := $nodepool.Nodes }}
         {{- $virtualMachineResourceName   := printf "%s_%s" $node.Name $resourceSuffix }}

--- a/templates/terraformer/gcp/networking/networking.tpl
+++ b/templates/terraformer/gcp/networking/networking.tpl
@@ -11,6 +11,13 @@
 
 {{- $resourceSuffix := printf "%s_%s_%s" $region $specName $uniqueFingerPrint }}
 
+# Fetch available zones for this region
+data "google_compute_zones" "available_{{ $resourceSuffix }}" {
+  provider = google.nodepool_{{ $resourceSuffix }}
+  region   = "{{ $region }}"
+  status   = "UP"
+}
+
 {{- if $isKubernetesCluster }}
     {{- $varStorageDiskName  := printf "gcp_storage_disk_name_%s" $resourceSuffix }}
     variable "{{ $varStorageDiskName}}" {

--- a/templates/terraformer/gcp/nodepool/node.tpl
+++ b/templates/terraformer/gcp/nodepool/node.tpl
@@ -11,7 +11,7 @@
 {{- $specName       := $nodepool.Details.Provider.SpecName }}
 {{- $resourceSuffix := printf "%s_%s_%s" $region $specName $uniqueFingerPrint }}
 
-    {{- range $node := $nodepool.Nodes }}
+    {{- range $nodeIndex, $node := $nodepool.Nodes }}
 
         {{- $computeExternalIpResourceName  := printf "%s_%s_external_ip" $node.Name $resourceSuffix }}
         {{- $computeExternalIpName          := printf "i%s" $node.Name }}
@@ -29,7 +29,18 @@
 
         resource "google_compute_instance" "{{ $computeInstanceResourceName}}" {
           provider                  = google.nodepool_{{ $resourceSuffix }}
+        {{- if $nodepool.Details.Zone }}
           zone                      = "{{ $nodepool.Details.Zone }}"
+        {{- else }}
+          zone                      = element(data.google_compute_zones.available_{{ $resourceSuffix }}.names, {{ $nodeIndex }} % length(data.google_compute_zones.available_{{ $resourceSuffix }}.names))
+
+          lifecycle {
+            precondition {
+              condition     = length(data.google_compute_zones.available_{{ $resourceSuffix }}.names) > 0
+              error_message = "No available zones found for region {{ $region }}. Check GCP permissions or region configuration."
+            }
+          }
+        {{- end }}
           name                      = "{{ $node.Name }}"
           machine_type              = "{{ $nodepool.Details.ServerType }}"
           description   = "Managed by Claudie for cluster {{ $clusterName }}-{{ $clusterHash }}"
@@ -147,7 +158,18 @@ EOF
               # suffix 'd' as otherwise the creation of the VM instance and attachment of the disk will fail, if having the same name as the node.
               name     = "{{ $computeDiskName }}"
               type     = "pd-ssd"
+            {{- if $nodepool.Details.Zone }}
               zone     = "{{ $nodepool.Details.Zone }}"
+            {{- else }}
+              zone     = element(data.google_compute_zones.available_{{ $resourceSuffix }}.names, {{ $nodeIndex }} % length(data.google_compute_zones.available_{{ $resourceSuffix }}.names))
+
+              lifecycle {
+                precondition {
+                  condition     = length(data.google_compute_zones.available_{{ $resourceSuffix }}.names) > 0
+                  error_message = "No available zones found for region {{ $region }}. Check GCP permissions or region configuration."
+                }
+              }
+            {{- end }}
               size     = {{ $nodepool.Details.StorageDiskSize }}
 
               labels = {
@@ -160,7 +182,18 @@ EOF
               provider    = google.nodepool_{{ $resourceSuffix }}
               disk        = google_compute_disk.{{ $computeDiskResourceName }}.id
               instance    = google_compute_instance.{{ $computeInstanceResourceName }}.id
+            {{- if $nodepool.Details.Zone }}
               zone        = "{{ $nodepool.Details.Zone }}"
+            {{- else }}
+              zone        = element(data.google_compute_zones.available_{{ $resourceSuffix }}.names, {{ $nodeIndex }} % length(data.google_compute_zones.available_{{ $resourceSuffix }}.names))
+
+              lifecycle {
+                precondition {
+                  condition     = length(data.google_compute_zones.available_{{ $resourceSuffix }}.names) > 0
+                  error_message = "No available zones found for region {{ $region }}. Check GCP permissions or region configuration."
+                }
+              }
+            {{- end }}
               device_name = var.{{ $varStorageDiskName }}
             }
             {{- end }}

--- a/templates/terraformer/gcp/nodepool/node.tpl
+++ b/templates/terraformer/gcp/nodepool/node.tpl
@@ -33,13 +33,6 @@
           zone                      = "{{ $nodepool.Details.Zone }}"
         {{- else }}
           zone                      = element(data.google_compute_zones.available_{{ $resourceSuffix }}.names, {{ $nodeIndex }} % length(data.google_compute_zones.available_{{ $resourceSuffix }}.names))
-
-          lifecycle {
-            precondition {
-              condition     = length(data.google_compute_zones.available_{{ $resourceSuffix }}.names) > 0
-              error_message = "No available zones found for region {{ $region }}. Check GCP permissions or region configuration."
-            }
-          }
         {{- end }}
           name                      = "{{ $node.Name }}"
           machine_type              = "{{ $nodepool.Details.ServerType }}"
@@ -162,13 +155,6 @@ EOF
               zone     = "{{ $nodepool.Details.Zone }}"
             {{- else }}
               zone     = element(data.google_compute_zones.available_{{ $resourceSuffix }}.names, {{ $nodeIndex }} % length(data.google_compute_zones.available_{{ $resourceSuffix }}.names))
-
-              lifecycle {
-                precondition {
-                  condition     = length(data.google_compute_zones.available_{{ $resourceSuffix }}.names) > 0
-                  error_message = "No available zones found for region {{ $region }}. Check GCP permissions or region configuration."
-                }
-              }
             {{- end }}
               size     = {{ $nodepool.Details.StorageDiskSize }}
 
@@ -186,13 +172,6 @@ EOF
               zone        = "{{ $nodepool.Details.Zone }}"
             {{- else }}
               zone        = element(data.google_compute_zones.available_{{ $resourceSuffix }}.names, {{ $nodeIndex }} % length(data.google_compute_zones.available_{{ $resourceSuffix }}.names))
-
-              lifecycle {
-                precondition {
-                  condition     = length(data.google_compute_zones.available_{{ $resourceSuffix }}.names) > 0
-                  error_message = "No available zones found for region {{ $region }}. Check GCP permissions or region configuration."
-                }
-              }
             {{- end }}
               device_name = var.{{ $varStorageDiskName }}
             }

--- a/templates/terraformer/oci/networking/networking.tpl
+++ b/templates/terraformer/oci/networking/networking.tpl
@@ -19,6 +19,15 @@ locals {
 {{- range $_, $region := .Data.Regions }}
 
 {{- $resourceSuffix := printf "%s_%s_%s" $region $specName $uniqueFingerPrint }}
+{{- $varCompartmentID  := printf "default_compartment_id_%s" $resourceSuffix }}
+
+# Fetch available availability domains for the region
+# Note: Availability domains must be queried using the tenancy OCID (root compartment),
+# not a sub-compartment OCID, as ADs are tenancy-level resources.
+data "oci_identity_availability_domains" "available_{{ $resourceSuffix }}" {
+  provider       = oci.nodepool_{{ $resourceSuffix }}
+  compartment_id = "{{ $.Data.Provider.GetOci.TenancyOCID }}"
+}
 
 {{- if $isKubernetesCluster }}
     {{- $varStorageDiskName  := printf "oci_storage_disk_name_%s" $resourceSuffix }}

--- a/templates/terraformer/oci/networking/networking.tpl
+++ b/templates/terraformer/oci/networking/networking.tpl
@@ -19,7 +19,6 @@ locals {
 {{- range $_, $region := .Data.Regions }}
 
 {{- $resourceSuffix := printf "%s_%s_%s" $region $specName $uniqueFingerPrint }}
-{{- $varCompartmentID  := printf "default_compartment_id_%s" $resourceSuffix }}
 
 # Fetch available availability domains for the region
 # Note: Availability domains must be queried using the tenancy OCID (root compartment),

--- a/templates/terraformer/oci/nodepool/node.tpl
+++ b/templates/terraformer/oci/nodepool/node.tpl
@@ -11,7 +11,7 @@
 {{- $specName       := $nodepool.Details.Provider.SpecName }}
 {{- $resourceSuffix := printf "%s_%s_%s" $region $specName $uniqueFingerPrint }}
 
-    {{- range $node := $nodepool.Nodes }}
+    {{- range $nodeIndex, $node := $nodepool.Nodes }}
 
         {{- $coreInstanceResourceName     := printf "%s_%s" $node.Name $resourceSuffix }}
         {{- $coreSubnetResourceName       := printf "%s_%s_subnet" $nodepool.Name $resourceSuffix }}
@@ -22,7 +22,11 @@
         resource "oci_core_instance" "{{ $coreInstanceResourceName }}" {
           provider            = oci.nodepool_{{ $resourceSuffix }}
           compartment_id      = var.{{ $varCompartmentID }}
+        {{- if $nodepool.Details.Zone }}
           availability_domain = "{{ $nodepool.Details.Zone }}"
+        {{- else }}
+          availability_domain = element(data.oci_identity_availability_domains.available_{{ $resourceSuffix }}.availability_domains, {{ $nodeIndex }} % length(data.oci_identity_availability_domains.available_{{ $resourceSuffix }}.availability_domains)).name
+        {{- end }}
           shape               = "{{ $nodepool.Details.ServerType }}"
           display_name        = "{{ $node.Name }}"
 
@@ -161,7 +165,11 @@
             resource "oci_core_volume" "{{ $coreVolumeResourceName }}" {
               provider            = oci.nodepool_{{ $resourceSuffix }}
               compartment_id      = var.{{ $varCompartmentID }}
+            {{- if $nodepool.Details.Zone }}
               availability_domain = "{{ $nodepool.Details.Zone }}"
+            {{- else }}
+              availability_domain = element(data.oci_identity_availability_domains.available_{{ $resourceSuffix }}.availability_domains, {{ $nodeIndex }} % length(data.oci_identity_availability_domains.available_{{ $resourceSuffix }}.availability_domains)).name
+            {{- end }}
               size_in_gbs         = "{{ $nodepool.Details.StorageDiskSize }}"
               display_name        = "{{ $coreVolumeName }}"
               vpus_per_gb         = 10


### PR DESCRIPTION
## Summary
- Implements uniform distribution of nodes across availability zones when zone is not specified in the InputManifest
- Adds zone discovery data sources for all cloud providers (AWS, Azure, GCP, OCI)
- Uses round-robin distribution via modulo operator (`nodeIndex % zoneCount`)

### Provider-specific implementations:
- **AWS**: Creates per-node subnets with dynamic CIDR allocation (supports up to 256 nodes)
- **Azure**: Uses `azurerm_location` data source with null fallback for regions without AZ support
- **GCP**: Uses `google_compute_zones` data source
- **OCI**: Uses `oci_identity_availability_domains` with tenancy OCID

Closes https://github.com/berops/claudie/issues/1629