### PR TITLE
feat(gcp): add guest_accelerator block for GPU support

### DIFF
--- a/templates/terraformer/gcp/nodepool/node.tpl
+++ b/templates/terraformer/gcp/nodepool/node.tpl
@@ -39,6 +39,20 @@
           description   = "Managed by Claudie for cluster {{ $clusterName }}-{{ $clusterHash }}"
           allow_stopping_for_update = true
 
+          {{- /* GPU Guest Accelerator Configuration */}}
+          {{- if and $nodepool.Details.MachineSpec $nodepool.Details.MachineSpec.NvidiaGpuCount }}
+          {{- if gt $nodepool.Details.MachineSpec.NvidiaGpuCount 0 }}
+          guest_accelerator {
+            type  = "{{ $nodepool.Details.MachineSpec.NvidiaGpuType }}"
+            count = {{ $nodepool.Details.MachineSpec.NvidiaGpuCount }}
+          }
+
+          scheduling {
+            on_host_maintenance = "TERMINATE"
+          }
+          {{- end }}
+          {{- end }}
+
           network_interface {
             subnetwork = google_compute_subnetwork.{{ $computeSubnetResourceName }}.self_link
             access_config {


### PR DESCRIPTION
## Summary

**Depends on:** berops/claudie#1952

Related to berops/claudie#1845

This PR adds the `guest_accelerator` block to GCP compute instances to enable GPU support.

### Changes

Adds GPU configuration to `templates/terraformer/gcp/nodepool/node.tpl`:

```hcl
guest_accelerator {
  type  = "{{ $nodepool.Details.MachineSpec.NvidiaGpuType }}"
  count = {{ $nodepool.Details.MachineSpec.NvidiaGpuCount }}
}

scheduling {
  on_host_maintenance = "TERMINATE"
}
```

### Notes

- The `guest_accelerator` block is only rendered when `MachineSpec.NvidiaGpuCount > 0`
- When using GPUs, `on_host_maintenance` must be set to `TERMINATE` (live migration not supported)
- Requires corresponding changes in [claudie](https://github.com/berops/claudie/pull/1952) for the `NvidiaGpuCount` and `NvidiaGpuType` fields

