### PR TITLE
fix: replace deprecated datacenter with location for Hetzner servers

### DIFF
--- a/templates/terraformer/hetzner/nodepool/node.tpl
+++ b/templates/terraformer/hetzner/nodepool/node.tpl
@@ -37,7 +37,7 @@
           server_type   = "{{ $nodepool.Details.ServerType }}"
           image         = "{{ $nodepool.Details.Image }}"
           firewall_ids  = [ hcloud_firewall.{{ $firewallResourceName }}.id ]
-          datacenter    = "{{ $nodepool.Details.Zone }}"
+          location      = "{{ $nodepool.Details.Region }}"
           public_net {
              ipv6_enabled = false
           }


### PR DESCRIPTION
## Summary
- Replaces the deprecated `datacenter` attribute with `location` in the `hcloud_server` resource
- Uses `$nodepool.Details.Region` to match the existing pattern in `hcloud_volume`

Closes #20

## References
- [Terraform hcloud_server docs](https://registry.terraform.io/providers/hetznercloud/hcloud/latest/docs/resources/server#datacenter-attribute)
- [Hetzner API Changelog](https://docs.hetzner.cloud/changelog#2025-12-16-phasing-out-datacenters)

## Test plan
- [x] Verify `terraform plan` shows no changes for existing infrastructure
- [x] Test new server creation with the updated template

🤖 Generated with [Claude Code](https://claude.com/claude-code)