### PR TITLE
Fix: AWS static IP on VM

### DIFF
--- a/templates/terraformer/aws/nodepool/node.tpl
+++ b/templates/terraformer/aws/nodepool/node.tpl
@@ -38,6 +38,8 @@ resource "aws_key_pair" "{{ $keypairResourceName }}" {
         {{- $isWorkerNodeWithDiskAttached := and (not $nodepool.IsControl) (gt $nodepool.Details.StorageDiskSize 0) }}
         {{- $volumeResourceName           := printf "%s_%s_volume" $node.Name $resourceSuffix }}
         {{- $volumeAttachmentResourceName := printf "%s_%s_volume_att" $node.Name $resourceSuffix }}
+        {{- $eipResourceName              := printf "%s_%s_eip" $node.Name $resourceSuffix }}
+        {{- $eipAssocResourceName         := printf "%s_%s_eip_assoc" $node.Name $resourceSuffix }}
 
         resource "aws_instance" "{{ $instanceResourceName }}" {
           provider          = aws.nodepool_{{ $resourceSuffix }}
@@ -49,7 +51,6 @@ resource "aws_key_pair" "{{ $keypairResourceName }}" {
           instance_type     = "{{ $nodepool.Details.ServerType }}"
           ami               = "{{ $nodepool.Details.Image }}"
 
-          associate_public_ip_address = true
           key_name               = aws_key_pair.{{ $keypairResourceName }}.key_name
           subnet_id              = aws_subnet.{{ $subnetResourceName }}.id
           vpc_security_group_ids = [aws_security_group.{{ $securityGroupResourceName }}.id]
@@ -165,13 +166,30 @@ fi
             {{- end }}
         {{- end }}
 
+        resource "aws_eip" "{{ $eipResourceName }}" {
+          provider = aws.nodepool_{{ $resourceSuffix }}
+          domain   = "vpc"
+
+          tags = {
+            Name            = "{{ $node.Name }}-eip"
+            Claudie-cluster = "{{ $clusterName }}-{{ $clusterHash }}"
+          }
+        }
+
+        resource "aws_eip_association" "{{ $eipAssocResourceName }}" {
+          provider      = aws.nodepool_{{ $resourceSuffix }}
+          instance_id   = aws_instance.{{ $instanceResourceName }}.id
+          allocation_id = aws_eip.{{ $eipResourceName }}.id
+        }
+
     {{- end }}
 
 output  "{{ $nodepool.Name }}_{{ $specName }}_{{ $uniqueFingerPrint }}" {
   value = {
     {{- range $_, $node := $nodepool.Nodes }}
-        {{- $instanceResourceName         := printf "%s_%s" $node.Name $resourceSuffix }}
-        "${aws_instance.{{ $instanceResourceName }}.tags_all.Name}" =  aws_instance.{{ $instanceResourceName}}.public_ip
+        {{- $instanceResourceName := printf "%s_%s" $node.Name $resourceSuffix }}
+        {{- $eipResourceName      := printf "%s_%s_eip" $node.Name $resourceSuffix }}
+        "${aws_instance.{{ $instanceResourceName }}.tags_all.Name}" = aws_eip.{{ $eipResourceName }}.public_ip
     {{- end }}
   }
 }

--- a/templates/terraformer/aws/nodepool/node.tpl
+++ b/templates/terraformer/aws/nodepool/node.tpl
@@ -137,6 +137,21 @@ fi
 
         {{- end }}
         }
+        
+        resource "aws_eip" "{{ $eipResourceName }}" {
+          provider = aws.nodepool_{{ $resourceSuffix }}
+
+          tags = {
+            Name            = "{{ $node.Name }}-eip"
+            Claudie-cluster = "{{ $clusterName }}-{{ $clusterHash }}"
+          }
+        }
+
+        resource "aws_eip_association" "{{ $eipAssocResourceName }}" {
+          provider      = aws.nodepool_{{ $resourceSuffix }}
+          instance_id   = aws_instance.{{ $instanceResourceName }}.id
+          allocation_id = aws_eip.{{ $eipResourceName }}.id
+        }
 
         {{- if $isKubernetesCluster }}
             {{- if $isWorkerNodeWithDiskAttached }}
@@ -165,21 +180,6 @@ fi
         }
             {{- end }}
         {{- end }}
-
-        resource "aws_eip" "{{ $eipResourceName }}" {
-          provider = aws.nodepool_{{ $resourceSuffix }}
-
-          tags = {
-            Name            = "{{ $node.Name }}-eip"
-            Claudie-cluster = "{{ $clusterName }}-{{ $clusterHash }}"
-          }
-        }
-
-        resource "aws_eip_association" "{{ $eipAssocResourceName }}" {
-          provider      = aws.nodepool_{{ $resourceSuffix }}
-          instance_id   = aws_instance.{{ $instanceResourceName }}.id
-          allocation_id = aws_eip.{{ $eipResourceName }}.id
-        }
 
     {{- end }}
 

--- a/templates/terraformer/aws/nodepool/node.tpl
+++ b/templates/terraformer/aws/nodepool/node.tpl
@@ -10,7 +10,7 @@
 {{- $region         := $nodepool.Details.Region }}
 {{- $specName       := $nodepool.Details.Provider.SpecName }}
 {{- $resourceSuffix := printf "%s_%s_%s" $region $specName $uniqueFingerPrint }}
-
+{{- $internetGatewayResourceName := printf "claudie_gateway_%s" $resourceSuffix }}
 {{- $keypairResourceName  := printf "key_%s_%s" $nodepool.Name $resourceSuffix }}
 {{- $keypairName          := printf "key-%s-%s-%s" $nodepool.Name $clusterHash $specName }}
 
@@ -42,7 +42,9 @@ resource "aws_key_pair" "{{ $keypairResourceName }}" {
         {{- $eipAssocResourceName         := printf "%s_%s_eip_assoc" $node.Name $resourceSuffix }}
 
         resource "aws_eip" "{{ $eipResourceName }}" {
-          provider = aws.nodepool_{{ $resourceSuffix }}
+          provider   = aws.nodepool_{{ $resourceSuffix }}
+          depends_on = [aws_internet_gateway.{{ $internetGatewayResourceName }}]
+          domain     = "vpc"
 
           tags = {
             Name            = "{{ $node.Name }}-eip"

--- a/templates/terraformer/aws/nodepool/node.tpl
+++ b/templates/terraformer/aws/nodepool/node.tpl
@@ -41,6 +41,21 @@ resource "aws_key_pair" "{{ $keypairResourceName }}" {
         {{- $eipResourceName              := printf "%s_%s_eip" $node.Name $resourceSuffix }}
         {{- $eipAssocResourceName         := printf "%s_%s_eip_assoc" $node.Name $resourceSuffix }}
 
+        resource "aws_eip" "{{ $eipResourceName }}" {
+          provider = aws.nodepool_{{ $resourceSuffix }}
+
+          tags = {
+            Name            = "{{ $node.Name }}-eip"
+            Claudie-cluster = "{{ $clusterName }}-{{ $clusterHash }}"
+          }
+        }
+
+        resource "aws_eip_association" "{{ $eipAssocResourceName }}" {
+          provider      = aws.nodepool_{{ $resourceSuffix }}
+          instance_id   = aws_instance.{{ $instanceResourceName }}.id
+          allocation_id = aws_eip.{{ $eipResourceName }}.id
+        }
+
         resource "aws_instance" "{{ $instanceResourceName }}" {
           provider          = aws.nodepool_{{ $resourceSuffix }}
         {{- if $nodepool.Details.Zone }}
@@ -138,21 +153,6 @@ fi
         {{- end }}
         }
         
-        resource "aws_eip" "{{ $eipResourceName }}" {
-          provider = aws.nodepool_{{ $resourceSuffix }}
-
-          tags = {
-            Name            = "{{ $node.Name }}-eip"
-            Claudie-cluster = "{{ $clusterName }}-{{ $clusterHash }}"
-          }
-        }
-
-        resource "aws_eip_association" "{{ $eipAssocResourceName }}" {
-          provider      = aws.nodepool_{{ $resourceSuffix }}
-          instance_id   = aws_instance.{{ $instanceResourceName }}.id
-          allocation_id = aws_eip.{{ $eipResourceName }}.id
-        }
-
         {{- if $isKubernetesCluster }}
             {{- if $isWorkerNodeWithDiskAttached }}
 

--- a/templates/terraformer/aws/nodepool/node.tpl
+++ b/templates/terraformer/aws/nodepool/node.tpl
@@ -168,7 +168,6 @@ fi
 
         resource "aws_eip" "{{ $eipResourceName }}" {
           provider = aws.nodepool_{{ $resourceSuffix }}
-          domain   = "vpc"
 
           tags = {
             Name            = "{{ $node.Name }}-eip"
@@ -188,7 +187,6 @@ output  "{{ $nodepool.Name }}_{{ $specName }}_{{ $uniqueFingerPrint }}" {
   value = {
     {{- range $_, $node := $nodepool.Nodes }}
         {{- $instanceResourceName := printf "%s_%s" $node.Name $resourceSuffix }}
-        {{- $eipResourceName      := printf "%s_%s_eip" $node.Name $resourceSuffix }}
         "${aws_instance.{{ $instanceResourceName }}.tags_all.Name}" = aws_eip.{{ $eipResourceName }}.public_ip
     {{- end }}
   }

--- a/templates/terraformer/aws/nodepool/node.tpl
+++ b/templates/terraformer/aws/nodepool/node.tpl
@@ -187,6 +187,7 @@ output  "{{ $nodepool.Name }}_{{ $specName }}_{{ $uniqueFingerPrint }}" {
   value = {
     {{- range $_, $node := $nodepool.Nodes }}
         {{- $instanceResourceName := printf "%s_%s" $node.Name $resourceSuffix }}
+        {{- $eipResourceName := printf "%s_%s_eip" $node.Name $resourceSuffix }}
         "${aws_instance.{{ $instanceResourceName }}.tags_all.Name}" = aws_eip.{{ $eipResourceName }}.public_ip
     {{- end }}
   }

--- a/templates/terraformer/aws/nodepool/node_networking.tpl
+++ b/templates/terraformer/aws/nodepool/node_networking.tpl
@@ -20,7 +20,6 @@ resource "aws_subnet" "{{ $subnetResourceName }}" {
   provider                = aws.nodepool_{{ $resourceSuffix }}
   vpc_id                  = aws_vpc.{{ $vpcResourceName }}.id
   cidr_block              = "{{ $subnetCIDR }}"
-  map_public_ip_on_launch = true
   availability_zone       = "{{ $nodepool.Details.Zone }}"
 
   tags = {
@@ -58,7 +57,6 @@ resource "aws_subnet" "{{ $subnetResourceName }}" {
   provider                = aws.nodepool_{{ $resourceSuffix }}
   vpc_id                  = aws_vpc.{{ $vpcResourceName }}.id
   cidr_block              = cidrsubnet("{{ $nodepool.Details.Cidr }}", {{ $newbits }}, {{ $nodeIndex }})
-  map_public_ip_on_launch = true
   availability_zone       = element(data.aws_availability_zones.available_{{ $resourceSuffix }}.names, {{ $nodeIndex }} % length(data.aws_availability_zones.available_{{ $resourceSuffix }}.names))
 
   tags = {


### PR DESCRIPTION
Replace dynamic public IPs with AWS Elastic IPs to ensure instances retain the same public IP address across stop/start cycles.

Close #24