### PR TITLE
feat: add Exoscale provider and DNS Terraform templates

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,19 +1,36 @@
+# IDEs and editors
 .idea/
-*.ini
+.vscode/
+
+# OS
+.DS_Store
+
+# Terraform / OpenTofu
 .terraform*
-clusters
-playground
-.vscode
-mongodb
 *.tfstate*
+
+# Credentials and keys
 *.pem
+*.ini
+*.conf
+
+# Build artifacts
+bin/
+__debug_bin
+
+# Clusters and manifests
+clusters/
+playground/
+.manifest*
 kubeone.yaml
 cluster.tar.gz
 cluster-kubeconfig
-*.conf
-__debug_bin
+mongodb/
+
+# Python
 /venv/
 /site/
-bin
-.manifest*
-.DS_Store
+
+# Claude
+.claude/
+CLAUDE.md

--- a/templates/terraformer/exoscale/dns/dns.tpl
+++ b/templates/terraformer/exoscale/dns/dns.tpl
@@ -1,0 +1,35 @@
+{{- $specName          := .Data.Provider.SpecName }}
+{{- $uniqueFingerPrint := .Fingerprint }}
+{{- $resourceSuffix    := printf "%s_%s" $specName $uniqueFingerPrint }}
+{{- $clusterID         := printf "%s-%s" .Data.ClusterName .Data.ClusterHash }}
+
+provider "exoscale" {
+  key    = "{{ .Data.Provider.GetExoscale.ApiKey }}"
+  secret = file("{{ $specName }}")
+  alias  = "dns_{{ $resourceSuffix }}"
+}
+
+data "exoscale_domain" "dns_zone_{{ $resourceSuffix }}" {
+  provider = exoscale.dns_{{ $resourceSuffix }}
+  name     = "{{ .Data.DNSZone }}"
+}
+
+{{ range $ip := .Data.RecordData.IP }}
+
+    {{- $escapedIPv4 := replaceAll $ip.V4 "." "_"}}
+    {{- $recordResourceName := printf "record_%s_%s" $escapedIPv4 $resourceSuffix }}
+
+    resource "exoscale_domain_record" "{{ $recordResourceName }}" {
+      provider    = exoscale.dns_{{ $resourceSuffix }}
+      domain      = data.exoscale_domain.dns_zone_{{ $resourceSuffix }}.id
+      name        = "{{ $.Data.Hostname }}"
+      content     = "{{ $ip.V4 }}"
+      record_type = "A"
+      ttl         = 300
+    }
+
+{{- end }}
+
+output "{{ $clusterID }}_{{ $resourceSuffix }}" {
+  value = { "{{ $clusterID }}-endpoint" = format("%s.%s", "{{ .Data.Hostname }}", "{{ .Data.DNSZone }}")}
+}

--- a/templates/terraformer/exoscale/dns/dns_alternative_names.tpl
+++ b/templates/terraformer/exoscale/dns/dns_alternative_names.tpl
@@ -5,21 +5,16 @@
 
 {{- if hasExtension .Data "AlternativeNamesExtension" }}
 	{{- range $_, $alternativeName := .Data.AlternativeNamesExtension.Names }}
+    {{- $recordResourceName := printf "record_%s_%s" $alternativeName $resourceSuffix }}
 
-        {{- range $ip := $.Data.RecordData.IP }}
-            {{- $escapedIPv4 := replaceAll $ip.V4 "." "_" }}
-            {{- $recordResourceName := printf "record_%s_%s_%s" $alternativeName $escapedIPv4 $resourceSuffix }}
-
-            resource "exoscale_domain_record" "{{ $recordResourceName }}" {
-                provider    = exoscale.dns_{{ $resourceSuffix }}
-                domain      = data.exoscale_domain.dns_zone_{{ $resourceSuffix }}.id
-                name        = "{{ $alternativeName }}"
-                content     = "{{ $ip.V4 }}"
-                record_type = "A"
-                ttl         = 300
-            }
-        {{- end }}
-
+    resource "exoscale_domain_record" "{{ $recordResourceName }}" {
+        provider    = exoscale.dns_{{ $resourceSuffix }}
+        domain      = data.exoscale_domain.dns_zone_{{ $resourceSuffix }}.id
+        name        = "{{ $alternativeName }}"
+        content     = "{{ $.Data.Hostname }}.{{ $.Data.DNSZone }}"
+        record_type = "CNAME"
+        ttl         = 300
+    }
 
 	output "{{ $clusterID }}_{{ $alternativeName }}_{{ $resourceSuffix }}" {
 	  value = { "{{ $clusterID }}-{{ $alternativeName }}-endpoint" = format("%s.%s", "{{ $alternativeName }}", "{{ $.Data.DNSZone }}")}

--- a/templates/terraformer/exoscale/dns/dns_alternative_names.tpl
+++ b/templates/terraformer/exoscale/dns/dns_alternative_names.tpl
@@ -1,0 +1,29 @@
+{{- $specName          := .Data.Provider.SpecName }}
+{{- $uniqueFingerPrint := .Fingerprint }}
+{{- $resourceSuffix    := printf "%s_%s" $specName $uniqueFingerPrint }}
+{{- $clusterID         := printf "%s-%s" .Data.ClusterName .Data.ClusterHash }}
+
+{{- if hasExtension .Data "AlternativeNamesExtension" }}
+	{{- range $_, $alternativeName := .Data.AlternativeNamesExtension.Names }}
+
+        {{- range $ip := $.Data.RecordData.IP }}
+            {{- $escapedIPv4 := replaceAll $ip.V4 "." "_" }}
+            {{- $recordResourceName := printf "record_%s_%s_%s" $alternativeName $escapedIPv4 $resourceSuffix }}
+
+            resource "exoscale_domain_record" "{{ $recordResourceName }}" {
+                provider    = exoscale.dns_{{ $resourceSuffix }}
+                domain      = data.exoscale_domain.dns_zone_{{ $resourceSuffix }}.id
+                name        = "{{ $alternativeName }}"
+                content     = "{{ $ip.V4 }}"
+                record_type = "A"
+                ttl         = 300
+            }
+        {{- end }}
+
+
+	output "{{ $clusterID }}_{{ $alternativeName }}_{{ $resourceSuffix }}" {
+	  value = { "{{ $clusterID }}-{{ $alternativeName }}-endpoint" = format("%s.%s", "{{ $alternativeName }}", "{{ $.Data.DNSZone }}")}
+	}
+
+	{{- end }}
+{{- end }}

--- a/templates/terraformer/exoscale/networking/networking.tpl
+++ b/templates/terraformer/exoscale/networking/networking.tpl
@@ -21,6 +21,8 @@ resource "exoscale_security_group_rule" "icmp_{{ $resourceSuffix }}" {
   security_group_id = exoscale_security_group.{{ $sgResourceName }}.id
   type              = "INGRESS"
   protocol          = "ICMP"
+  icmp_type         = 8
+  icmp_code         = 0
   cidr              = "0.0.0.0/0"
 }
 

--- a/templates/terraformer/exoscale/networking/networking.tpl
+++ b/templates/terraformer/exoscale/networking/networking.tpl
@@ -1,0 +1,75 @@
+{{- $clusterName           := .Data.ClusterData.ClusterName}}
+{{- $clusterHash           := .Data.ClusterData.ClusterHash}}
+{{- $specName              := .Data.Provider.SpecName }}
+{{- $uniqueFingerPrint     := .Fingerprint }}
+{{- $isKubernetesCluster   := eq .Data.ClusterData.ClusterType "K8s" }}
+{{- $isLoadbalancerCluster := eq .Data.ClusterData.ClusterType "LB" }}
+{{- $LoadBalancerRoles     := .Data.LBData.Roles }}
+{{- $K8sHasAPIServer       := .Data.K8sData.HasAPIServer }}
+{{- $resourceSuffix        := printf "%s_%s" $specName $uniqueFingerPrint }}
+
+{{- $sgResourceName := printf "sg_%s" $resourceSuffix }}
+{{- $sgName         := printf "sg%s%s" $clusterHash $uniqueFingerPrint }}
+
+resource "exoscale_security_group" "{{ $sgResourceName }}" {
+  provider = exoscale.nodepool_{{ $resourceSuffix }}
+  name     = "{{ $sgName }}"
+}
+
+resource "exoscale_security_group_rule" "icmp_{{ $resourceSuffix }}" {
+  provider          = exoscale.nodepool_{{ $resourceSuffix }}
+  security_group_id = exoscale_security_group.{{ $sgResourceName }}.id
+  type              = "INGRESS"
+  protocol          = "ICMP"
+  cidr              = "0.0.0.0/0"
+}
+
+resource "exoscale_security_group_rule" "ssh_{{ $resourceSuffix }}" {
+  provider          = exoscale.nodepool_{{ $resourceSuffix }}
+  security_group_id = exoscale_security_group.{{ $sgResourceName }}.id
+  type              = "INGRESS"
+  protocol          = "TCP"
+  start_port        = 22
+  end_port          = 22
+  cidr              = "0.0.0.0/0"
+}
+
+resource "exoscale_security_group_rule" "wireguard_{{ $resourceSuffix }}" {
+  provider          = exoscale.nodepool_{{ $resourceSuffix }}
+  security_group_id = exoscale_security_group.{{ $sgResourceName }}.id
+  type              = "INGRESS"
+  protocol          = "UDP"
+  start_port        = 51820
+  end_port          = 51820
+  cidr              = "0.0.0.0/0"
+}
+
+{{- if $isKubernetesCluster }}
+  {{- if $K8sHasAPIServer }}
+
+resource "exoscale_security_group_rule" "kube_api_{{ $resourceSuffix }}" {
+  provider          = exoscale.nodepool_{{ $resourceSuffix }}
+  security_group_id = exoscale_security_group.{{ $sgResourceName }}.id
+  type              = "INGRESS"
+  protocol          = "TCP"
+  start_port        = 6443
+  end_port          = 6443
+  cidr              = "0.0.0.0/0"
+}
+  {{- end }}
+{{- end }}
+
+{{- if $isLoadbalancerCluster }}
+  {{- range $role := $LoadBalancerRoles }}
+
+resource "exoscale_security_group_rule" "lb_{{ $role.Port }}_{{ $resourceSuffix }}" {
+  provider          = exoscale.nodepool_{{ $resourceSuffix }}
+  security_group_id = exoscale_security_group.{{ $sgResourceName }}.id
+  type              = "INGRESS"
+  protocol          = "{{ upper $role.Protocol }}"
+  start_port        = {{ $role.Port }}
+  end_port          = {{ $role.Port }}
+  cidr              = "0.0.0.0/0"
+}
+  {{- end }}
+{{- end }}

--- a/templates/terraformer/exoscale/nodepool/node.tpl
+++ b/templates/terraformer/exoscale/nodepool/node.tpl
@@ -1,0 +1,160 @@
+{{- $clusterName           := .Data.ClusterData.ClusterName}}
+{{- $clusterHash           := .Data.ClusterData.ClusterHash}}
+{{- $uniqueFingerPrint     := .Fingerprint }}
+{{- $isKubernetesCluster   := eq .Data.ClusterData.ClusterType "K8s" }}
+{{- $isLoadbalancerCluster := eq .Data.ClusterData.ClusterType "LB" }}
+
+
+{{- range $nodepool := .Data.NodePools }}
+
+{{- $specName       := $nodepool.Details.Provider.SpecName }}
+{{- $resourceSuffix := printf "%s_%s" $specName $uniqueFingerPrint }}
+
+{{- $sshKeyResourceName := printf "key_%s_%s" $nodepool.Name $resourceSuffix }}
+{{- $sshKeyName         := printf "key-%s-%s-%s" $nodepool.Name $clusterHash $specName }}
+{{- $templateDataName   := printf "template_%s_%s" $nodepool.Name $resourceSuffix }}
+
+    resource "exoscale_ssh_key" "{{ $sshKeyResourceName }}" {
+      provider   = exoscale.nodepool_{{ $resourceSuffix }}
+      name       = "{{ $sshKeyName }}"
+      public_key = file("./{{ $nodepool.Name }}")
+    }
+
+    data "exoscale_template" "{{ $templateDataName }}" {
+      provider = exoscale.nodepool_{{ $resourceSuffix }}
+      zone     = "{{ $nodepool.Details.Region }}"
+      name     = "{{ $nodepool.Details.Image }}"
+    }
+
+    {{- range $node := $nodepool.Nodes }}
+
+        {{- $serverResourceName           := printf "%s_%s" $node.Name $resourceSuffix }}
+        {{- $sgResourceName               := printf "sg_%s" $resourceSuffix }}
+        {{- $isWorkerNodeWithDiskAttached := and (not $nodepool.IsControl) (gt $nodepool.Details.StorageDiskSize 0) }}
+        {{- $volumeResourceName           := printf "%s_%s_volume" $node.Name $resourceSuffix }}
+
+        {{- if $isKubernetesCluster }}
+            {{- if $isWorkerNodeWithDiskAttached }}
+
+            {{- $volumeName := printf "%sd" $node.Name }}
+
+            resource "exoscale_block_storage_volume" "{{ $volumeResourceName }}" {
+              provider = exoscale.nodepool_{{ $resourceSuffix }}
+              zone     = "{{ $nodepool.Details.Region }}"
+              name     = "{{ $volumeName }}"
+              size     = {{ $nodepool.Details.StorageDiskSize }}
+
+              labels = {
+                "managed-by"      = "Claudie"
+                "claudie-cluster" = "{{ $clusterName }}-{{ $clusterHash }}"
+              }
+            }
+
+            {{- end }}
+        {{- end }}
+
+        resource "exoscale_compute_instance" "{{ $serverResourceName }}" {
+          provider    = exoscale.nodepool_{{ $resourceSuffix }}
+          zone        = "{{ $nodepool.Details.Region }}"
+          name        = "{{ $node.Name }}"
+          template_id = data.exoscale_template.{{ $templateDataName }}.id
+          type        = "{{ $nodepool.Details.ServerType }}"
+          ssh_keys    = [exoscale_ssh_key.{{ $sshKeyResourceName }}.name]
+          security_group_ids = [exoscale_security_group.{{ $sgResourceName }}.id]
+
+        {{- if $isLoadbalancerCluster }}
+          disk_size   = 50
+        {{- end }}
+        {{- if $isKubernetesCluster }}
+          disk_size   = 100
+
+            {{- if $isWorkerNodeWithDiskAttached }}
+          block_storage_volume_ids = [exoscale_block_storage_volume.{{ $volumeResourceName }}.id]
+            {{- end }}
+        {{- end }}
+
+          labels = {
+            "managed-by"      = "Claudie"
+            "claudie-cluster" = "{{ $clusterName }}-{{ $clusterHash }}"
+          }
+
+        {{- if $isLoadbalancerCluster }}
+          user_data = <<EOF
+#!/bin/bash
+# Enable root SSH access
+mkdir -p /root/.ssh
+chmod 700 /root/.ssh
+if [ -f /home/ubuntu/.ssh/authorized_keys ]; then
+    sed -n 's/^.*ssh-rsa/ssh-rsa/p' /home/ubuntu/.ssh/authorized_keys > /root/.ssh/authorized_keys
+    chmod 600 /root/.ssh/authorized_keys
+fi
+echo 'PermitRootLogin without-password' >> /etc/ssh/sshd_config
+echo 'PubkeyAuthentication yes' >> /etc/ssh/sshd_config
+echo 'PubkeyAcceptedKeyTypes=+ssh-rsa' >> /etc/ssh/sshd_config
+sshd_active=$(systemctl is-active sshd 2>/dev/null || true)
+ssh_active=$(systemctl is-active ssh 2>/dev/null || true)
+if [ "$sshd_active" = "active" ]; then
+    systemctl restart sshd
+fi
+if [ "$ssh_active" = "active" ]; then
+    systemctl restart ssh
+fi
+EOF
+        {{- end }}
+
+        {{- if $isKubernetesCluster }}
+          user_data = <<EOF
+#!/bin/bash
+# Enable root SSH access
+mkdir -p /root/.ssh
+chmod 700 /root/.ssh
+if [ -f /home/ubuntu/.ssh/authorized_keys ]; then
+    sed -n 's/^.*ssh-rsa/ssh-rsa/p' /home/ubuntu/.ssh/authorized_keys > /root/.ssh/authorized_keys
+    chmod 600 /root/.ssh/authorized_keys
+fi
+echo 'PermitRootLogin without-password' >> /etc/ssh/sshd_config
+echo 'PubkeyAuthentication yes' >> /etc/ssh/sshd_config
+echo 'PubkeyAcceptedKeyTypes=+ssh-rsa' >> /etc/ssh/sshd_config
+sshd_active=$(systemctl is-active sshd 2>/dev/null || true)
+ssh_active=$(systemctl is-active ssh 2>/dev/null || true)
+if [ "$sshd_active" = "active" ]; then
+    systemctl restart sshd
+fi
+if [ "$ssh_active" = "active" ]; then
+    systemctl restart ssh
+fi
+
+# Create longhorn volume directory
+mkdir -p /opt/claudie/data
+
+            {{- if $isWorkerNodeWithDiskAttached }}
+
+# Mount block storage volume only when not mounted yet
+sleep 50
+disk=$(ls -l /dev/disk/by-id | grep "${exoscale_block_storage_volume.{{ $volumeResourceName }}.id}" | awk '{print $NF}')
+disk=$(basename "$disk")
+if ! grep -qs "/dev/$disk" /proc/mounts; then
+  if ! blkid /dev/$disk | grep -q "TYPE=\"xfs\""; then
+    mkfs.xfs /dev/$disk
+  fi
+  mount /dev/$disk /opt/claudie/data
+  echo "/dev/$disk /opt/claudie/data xfs defaults 0 0" >> /etc/fstab
+fi
+
+            {{- end }}
+EOF
+
+        {{- end }}
+        }
+
+    {{- end }}
+
+output "{{ $nodepool.Name }}_{{ $specName }}_{{ $uniqueFingerPrint }}" {
+  value = {
+    {{- range $node := $nodepool.Nodes }}
+        {{- $serverResourceName := printf "%s_%s" $node.Name $resourceSuffix }}
+        "${exoscale_compute_instance.{{ $serverResourceName }}.name}" = exoscale_compute_instance.{{ $serverResourceName }}.public_ip_address
+    {{- end }}
+  }
+}
+{{- end }}

--- a/templates/terraformer/exoscale/nodepool/node.tpl
+++ b/templates/terraformer/exoscale/nodepool/node.tpl
@@ -131,7 +131,10 @@ mkdir -p /opt/claudie/data
 
 # Mount block storage volume only when not mounted yet
 sleep 50
-disk=$(ls -l /dev/disk/by-id | grep "${exoscale_block_storage_volume.{{ $volumeResourceName }}.id}" | awk '{print $NF}')
+# Linux virtio driver truncates serial numbers to 20 chars, so we match on a prefix of the volume UUID
+volume_id="${exoscale_block_storage_volume.{{ $volumeResourceName }}.id}"
+short_id=$(echo "$volume_id" | cut -c1-20)
+disk=$(ls -l /dev/disk/by-id | grep "$short_id" | awk '{print $NF}')
 disk=$(basename "$disk")
 if ! grep -qs "/dev/$disk" /proc/mounts; then
   if ! blkid /dev/$disk | grep -q "TYPE=\"xfs\""; then

--- a/templates/terraformer/exoscale/provider/provider.tpl
+++ b/templates/terraformer/exoscale/provider/provider.tpl
@@ -1,0 +1,9 @@
+{{- $specName          := .Data.Provider.SpecName }}
+{{- $uniqueFingerPrint := .Fingerprint }}
+{{- $resourceSuffix    := printf "%s_%s" $specName $uniqueFingerPrint }}
+
+provider "exoscale" {
+  key    = "{{ .Data.Provider.GetExoscale.ApiKey }}"
+  secret = file("{{ $specName }}")
+  alias  = "nodepool_{{ $resourceSuffix }}"
+}


### PR DESCRIPTION
Part of berops/claudie#1975

## Summary
- Adds Exoscale Terraform templates for compute infrastructure and DNS record management
- Required by berops/claudie#1978 (Exoscale cloud provider support)

## Templates
- **`exoscale/provider/provider.tpl`** — Exoscale provider config (api key/secret)
- **`exoscale/networking/networking.tpl`** — Security group with firewall rules (WireGuard, SSH, ICMP, Kubernetes ports)
- **`exoscale/nodepool/node.tpl`** — Compute instance provisioning (template lookup, SSH key, security group)
- **`exoscale/dns/dns.tpl`** — DNS zone lookup + A record creation
- **`exoscale/dns/dns_alternative_names.tpl`** — Alternative DNS A records

## Test plan
- [x] E2E: Single-provider cluster (ch-gva-2)
- [x] E2E: Multi-cloud cluster (Exoscale + GCP + AWS)
- [x] E2E: Autoscaling (scale-up and scale-down)
- [x] E2E: GPU instance (gpu2.small)
- [x] E2E: DNS record creation with Exoscale DNS zone — A record created, Envoy HTTP proxy verified with round-robin across nodes

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## New Features
* Added comprehensive Exoscale cloud platform support for infrastructure management:
  * DNS configuration with zone and A record management
  * Network security with dynamic firewall rule creation
  * Compute instance and node pool provisioning with block storage
  * Support for Kubernetes and Load Balancer cluster types
  * Alternative DNS names and secure provider authentication

<!-- end of auto-generated comment: release notes by coderabbit.ai -->