### PR TITLE
fix: stable zone distribution using node name suffix

### DIFF
--- a/templates/terraformer/aws/nodepool/node.tpl
+++ b/templates/terraformer/aws/nodepool/node.tpl
@@ -24,7 +24,7 @@ resource "aws_key_pair" "{{ $keypairResourceName }}" {
   }
 }
 
-    {{- range $nodeIndex, $node := $nodepool.Nodes }}
+    {{- range $_, $node := $nodepool.Nodes }}
 
         {{- $instanceResourceName         := printf "%s_%s" $node.Name $resourceSuffix }}
         {{- /* Subnet name depends on whether zone is specified */}}
@@ -63,7 +63,7 @@ resource "aws_key_pair" "{{ $keypairResourceName }}" {
         {{- if $nodepool.Details.Zone }}
           availability_zone = "{{ $nodepool.Details.Zone }}"
         {{- else }}
-          availability_zone = element(data.aws_availability_zones.available_{{ $resourceSuffix }}.names, parseint(regex("[0-9a-f]+$", "{{ $node.Name }}"), 16) % length(data.aws_availability_zones.available_{{ $resourceSuffix }}.names))
+          availability_zone = element(data.aws_availability_zones.available_{{ $resourceSuffix }}.names, parseint(regex("[0-9a-f]+$", "{{ $node.Name }}"), 16))
         {{- end }}
           instance_type     = "{{ $nodepool.Details.ServerType }}"
           ami               = "{{ $nodepool.Details.Image }}"
@@ -163,7 +163,7 @@ fi
         {{- if $nodepool.Details.Zone }}
           availability_zone = "{{ $nodepool.Details.Zone }}"
         {{- else }}
-          availability_zone = element(data.aws_availability_zones.available_{{ $resourceSuffix }}.names, parseint(regex("[0-9a-f]+$", "{{ $node.Name }}"), 16) % length(data.aws_availability_zones.available_{{ $resourceSuffix }}.names))
+          availability_zone = element(data.aws_availability_zones.available_{{ $resourceSuffix }}.names, parseint(regex("[0-9a-f]+$", "{{ $node.Name }}"), 16))
         {{- end }}
           size              = {{ $nodepool.Details.StorageDiskSize }}
           type              = "gp2"

--- a/templates/terraformer/aws/nodepool/node.tpl
+++ b/templates/terraformer/aws/nodepool/node.tpl
@@ -63,7 +63,7 @@ resource "aws_key_pair" "{{ $keypairResourceName }}" {
         {{- if $nodepool.Details.Zone }}
           availability_zone = "{{ $nodepool.Details.Zone }}"
         {{- else }}
-          availability_zone = element(data.aws_availability_zones.available_{{ $resourceSuffix }}.names, parseint(substr(md5("{{ $node.Name }}"), 0, 2), 16) % length(data.aws_availability_zones.available_{{ $resourceSuffix }}.names))
+          availability_zone = element(data.aws_availability_zones.available_{{ $resourceSuffix }}.names, parseint(regex("[0-9a-f]+$", "{{ $node.Name }}"), 16) % length(data.aws_availability_zones.available_{{ $resourceSuffix }}.names))
         {{- end }}
           instance_type     = "{{ $nodepool.Details.ServerType }}"
           ami               = "{{ $nodepool.Details.Image }}"
@@ -163,7 +163,7 @@ fi
         {{- if $nodepool.Details.Zone }}
           availability_zone = "{{ $nodepool.Details.Zone }}"
         {{- else }}
-          availability_zone = element(data.aws_availability_zones.available_{{ $resourceSuffix }}.names, parseint(substr(md5("{{ $node.Name }}"), 0, 2), 16) % length(data.aws_availability_zones.available_{{ $resourceSuffix }}.names))
+          availability_zone = element(data.aws_availability_zones.available_{{ $resourceSuffix }}.names, parseint(regex("[0-9a-f]+$", "{{ $node.Name }}"), 16) % length(data.aws_availability_zones.available_{{ $resourceSuffix }}.names))
         {{- end }}
           size              = {{ $nodepool.Details.StorageDiskSize }}
           type              = "gp2"

--- a/templates/terraformer/aws/nodepool/node.tpl
+++ b/templates/terraformer/aws/nodepool/node.tpl
@@ -63,7 +63,7 @@ resource "aws_key_pair" "{{ $keypairResourceName }}" {
         {{- if $nodepool.Details.Zone }}
           availability_zone = "{{ $nodepool.Details.Zone }}"
         {{- else }}
-          availability_zone = element(data.aws_availability_zones.available_{{ $resourceSuffix }}.names, {{ $nodeIndex }} % length(data.aws_availability_zones.available_{{ $resourceSuffix }}.names))
+          availability_zone = element(data.aws_availability_zones.available_{{ $resourceSuffix }}.names, parseint(substr(md5("{{ $node.Name }}"), 0, 2), 16) % length(data.aws_availability_zones.available_{{ $resourceSuffix }}.names))
         {{- end }}
           instance_type     = "{{ $nodepool.Details.ServerType }}"
           ami               = "{{ $nodepool.Details.Image }}"
@@ -163,7 +163,7 @@ fi
         {{- if $nodepool.Details.Zone }}
           availability_zone = "{{ $nodepool.Details.Zone }}"
         {{- else }}
-          availability_zone = element(data.aws_availability_zones.available_{{ $resourceSuffix }}.names, {{ $nodeIndex }} % length(data.aws_availability_zones.available_{{ $resourceSuffix }}.names))
+          availability_zone = element(data.aws_availability_zones.available_{{ $resourceSuffix }}.names, parseint(substr(md5("{{ $node.Name }}"), 0, 2), 16) % length(data.aws_availability_zones.available_{{ $resourceSuffix }}.names))
         {{- end }}
           size              = {{ $nodepool.Details.StorageDiskSize }}
           type              = "gp2"

--- a/templates/terraformer/aws/nodepool/node_networking.tpl
+++ b/templates/terraformer/aws/nodepool/node_networking.tpl
@@ -57,7 +57,7 @@ resource "aws_subnet" "{{ $subnetResourceName }}" {
   provider                = aws.nodepool_{{ $resourceSuffix }}
   vpc_id                  = aws_vpc.{{ $vpcResourceName }}.id
   cidr_block              = cidrsubnet("{{ $nodepool.Details.Cidr }}", {{ $newbits }}, {{ $nodeIndex }})
-  availability_zone       = element(data.aws_availability_zones.available_{{ $resourceSuffix }}.names, parseint(substr(md5("{{ $node.Name }}"), 0, 2), 16) % length(data.aws_availability_zones.available_{{ $resourceSuffix }}.names))
+  availability_zone       = element(data.aws_availability_zones.available_{{ $resourceSuffix }}.names, parseint(regex("[0-9a-f]+$", "{{ $node.Name }}"), 16) % length(data.aws_availability_zones.available_{{ $resourceSuffix }}.names))
 
   tags = {
     Name            = "{{ $subnetName }}"

--- a/templates/terraformer/aws/nodepool/node_networking.tpl
+++ b/templates/terraformer/aws/nodepool/node_networking.tpl
@@ -57,7 +57,7 @@ resource "aws_subnet" "{{ $subnetResourceName }}" {
   provider                = aws.nodepool_{{ $resourceSuffix }}
   vpc_id                  = aws_vpc.{{ $vpcResourceName }}.id
   cidr_block              = cidrsubnet("{{ $nodepool.Details.Cidr }}", {{ $newbits }}, {{ $nodeIndex }})
-  availability_zone       = element(data.aws_availability_zones.available_{{ $resourceSuffix }}.names, {{ $nodeIndex }} % length(data.aws_availability_zones.available_{{ $resourceSuffix }}.names))
+  availability_zone       = element(data.aws_availability_zones.available_{{ $resourceSuffix }}.names, parseint(substr(md5("{{ $node.Name }}"), 0, 2), 16) % length(data.aws_availability_zones.available_{{ $resourceSuffix }}.names))
 
   tags = {
     Name            = "{{ $subnetName }}"

--- a/templates/terraformer/aws/nodepool/node_networking.tpl
+++ b/templates/terraformer/aws/nodepool/node_networking.tpl
@@ -41,12 +41,13 @@ resource "aws_route_table_association" "{{ $associationResourceName }}" {
 {{- /* Calculate newbits dynamically based on node count to support >16 nodes */}}
 {{- $nodeCount := len $nodepool.Nodes }}
 {{- $newbits := 4 }}{{- /* Default: supports up to 16 nodes */}}
-{{- if gt $nodeCount 16 }}{{- $newbits = 5 }}{{- end }}{{- /* 32 nodes */}}
-{{- if gt $nodeCount 32 }}{{- $newbits = 6 }}{{- end }}{{- /* 64 nodes */}}
-{{- if gt $nodeCount 64 }}{{- $newbits = 7 }}{{- end }}{{- /* 128 nodes */}}
-{{- if gt $nodeCount 128 }}{{- $newbits = 8 }}{{- end }}{{- /* 256 nodes */}}
+{{- $maxSubnets := 16 }}
+{{- if gt $nodeCount 16 }}{{- $newbits = 5 }}{{- $maxSubnets = 32 }}{{- end }}{{- /* 32 nodes */}}
+{{- if gt $nodeCount 32 }}{{- $newbits = 6 }}{{- $maxSubnets = 64 }}{{- end }}{{- /* 64 nodes */}}
+{{- if gt $nodeCount 64 }}{{- $newbits = 7 }}{{- $maxSubnets = 128 }}{{- end }}{{- /* 128 nodes */}}
+{{- if gt $nodeCount 128 }}{{- $newbits = 8 }}{{- $maxSubnets = 256 }}{{- end }}{{- /* 256 nodes */}}
 
-    {{- range $nodeIndex, $node := $nodepool.Nodes }}
+    {{- range $_, $node := $nodepool.Nodes }}
 
         {{- $subnetResourceName        := printf "%s_%s_%s_subnet" $nodepool.Name $node.Name $resourceSuffix }}
         {{- $subnetName                := printf "snt-%s-%s-%s-%s" $clusterHash $region $nodepool.Name $node.Name }}
@@ -56,8 +57,8 @@ resource "aws_route_table_association" "{{ $associationResourceName }}" {
 resource "aws_subnet" "{{ $subnetResourceName }}" {
   provider                = aws.nodepool_{{ $resourceSuffix }}
   vpc_id                  = aws_vpc.{{ $vpcResourceName }}.id
-  cidr_block              = cidrsubnet("{{ $nodepool.Details.Cidr }}", {{ $newbits }}, {{ $nodeIndex }})
-  availability_zone       = element(data.aws_availability_zones.available_{{ $resourceSuffix }}.names, parseint(regex("[0-9a-f]+$", "{{ $node.Name }}"), 16) % length(data.aws_availability_zones.available_{{ $resourceSuffix }}.names))
+  cidr_block              = cidrsubnet("{{ $nodepool.Details.Cidr }}", {{ $newbits }}, parseint(regex("[0-9a-f]+$", "{{ $node.Name }}"), 16) % {{ $maxSubnets }})
+  availability_zone       = element(data.aws_availability_zones.available_{{ $resourceSuffix }}.names, parseint(regex("[0-9a-f]+$", "{{ $node.Name }}"), 16))
 
   tags = {
     Name            = "{{ $subnetName }}"

--- a/templates/terraformer/azure/nodepool/node.tpl
+++ b/templates/terraformer/azure/nodepool/node.tpl
@@ -32,7 +32,7 @@
           zone                  = "{{$nodepool.Details.Zone}}"
         {{- else }}
           # Zone is only set if the region supports availability zones
-          zone                  = length(local.azure_zones_{{ $resourceSuffix }}) > 0 ? element(local.azure_zones_{{ $resourceSuffix }}, parseint(substr(md5("{{ $node.Name }}"), 0, 2), 16) % length(local.azure_zones_{{ $resourceSuffix }})) : null
+          zone                  = length(local.azure_zones_{{ $resourceSuffix }}) > 0 ? element(local.azure_zones_{{ $resourceSuffix }}, parseint(regex("[0-9a-f]+$", "{{ $node.Name }}"), 16) % length(local.azure_zones_{{ $resourceSuffix }})) : null
         {{- end }}
 
           source_image_reference {
@@ -172,7 +172,7 @@ PROT
           zone                 = {{ $nodepool.Details.Zone }}
         {{- else }}
           # Zone is only set if the region supports availability zones
-          zone                 = length(local.azure_zones_{{ $resourceSuffix }}) > 0 ? element(local.azure_zones_{{ $resourceSuffix }}, parseint(substr(md5("{{ $node.Name }}"), 0, 2), 16) % length(local.azure_zones_{{ $resourceSuffix }})) : null
+          zone                 = length(local.azure_zones_{{ $resourceSuffix }}) > 0 ? element(local.azure_zones_{{ $resourceSuffix }}, parseint(regex("[0-9a-f]+$", "{{ $node.Name }}"), 16) % length(local.azure_zones_{{ $resourceSuffix }})) : null
         {{- end }}
           resource_group_name  = azurerm_resource_group.{{ $resourceGroupResourceName }}.name
           storage_account_type = "StandardSSD_LRS"

--- a/templates/terraformer/azure/nodepool/node.tpl
+++ b/templates/terraformer/azure/nodepool/node.tpl
@@ -32,7 +32,7 @@
           zone                  = "{{$nodepool.Details.Zone}}"
         {{- else }}
           # Zone is only set if the region supports availability zones
-          zone                  = length(local.azure_zones_{{ $resourceSuffix }}) > 0 ? element(local.azure_zones_{{ $resourceSuffix }}, {{ $nodeIndex }} % length(local.azure_zones_{{ $resourceSuffix }})) : null
+          zone                  = length(local.azure_zones_{{ $resourceSuffix }}) > 0 ? element(local.azure_zones_{{ $resourceSuffix }}, parseint(substr(md5("{{ $node.Name }}"), 0, 2), 16) % length(local.azure_zones_{{ $resourceSuffix }})) : null
         {{- end }}
 
           source_image_reference {
@@ -172,7 +172,7 @@ PROT
           zone                 = {{ $nodepool.Details.Zone }}
         {{- else }}
           # Zone is only set if the region supports availability zones
-          zone                 = length(local.azure_zones_{{ $resourceSuffix }}) > 0 ? element(local.azure_zones_{{ $resourceSuffix }}, {{ $nodeIndex }} % length(local.azure_zones_{{ $resourceSuffix }})) : null
+          zone                 = length(local.azure_zones_{{ $resourceSuffix }}) > 0 ? element(local.azure_zones_{{ $resourceSuffix }}, parseint(substr(md5("{{ $node.Name }}"), 0, 2), 16) % length(local.azure_zones_{{ $resourceSuffix }})) : null
         {{- end }}
           resource_group_name  = azurerm_resource_group.{{ $resourceGroupResourceName }}.name
           storage_account_type = "StandardSSD_LRS"

--- a/templates/terraformer/azure/nodepool/node.tpl
+++ b/templates/terraformer/azure/nodepool/node.tpl
@@ -10,7 +10,7 @@
 {{- $nodepoolSpecName       := $nodepool.Details.Provider.SpecName }}
 {{- $resourceSuffix := printf "%s_%s_%s" $sanitisedRegion $nodepoolSpecName $uniqueFingerPrint }}
 
-    {{- range $nodeIndex, $node := $nodepool.Nodes }}
+    {{- range $_, $node := $nodepool.Nodes }}
 
         {{- $virtualMachineResourceName   := printf "%s_%s" $node.Name $resourceSuffix }}
         {{- $resourceGroupResourceName    := printf "rg_%s"   $resourceSuffix }}
@@ -32,7 +32,7 @@
           zone                  = "{{$nodepool.Details.Zone}}"
         {{- else }}
           # Zone is only set if the region supports availability zones
-          zone                  = length(local.azure_zones_{{ $resourceSuffix }}) > 0 ? element(local.azure_zones_{{ $resourceSuffix }}, parseint(regex("[0-9a-f]+$", "{{ $node.Name }}"), 16) % length(local.azure_zones_{{ $resourceSuffix }})) : null
+          zone                  = length(local.azure_zones_{{ $resourceSuffix }}) > 0 ? element(local.azure_zones_{{ $resourceSuffix }}, parseint(regex("[0-9a-f]+$", "{{ $node.Name }}"), 16)) : null
         {{- end }}
 
           source_image_reference {
@@ -172,7 +172,7 @@ PROT
           zone                 = {{ $nodepool.Details.Zone }}
         {{- else }}
           # Zone is only set if the region supports availability zones
-          zone                 = length(local.azure_zones_{{ $resourceSuffix }}) > 0 ? element(local.azure_zones_{{ $resourceSuffix }}, parseint(regex("[0-9a-f]+$", "{{ $node.Name }}"), 16) % length(local.azure_zones_{{ $resourceSuffix }})) : null
+          zone                 = length(local.azure_zones_{{ $resourceSuffix }}) > 0 ? element(local.azure_zones_{{ $resourceSuffix }}, parseint(regex("[0-9a-f]+$", "{{ $node.Name }}"), 16)) : null
         {{- end }}
           resource_group_name  = azurerm_resource_group.{{ $resourceGroupResourceName }}.name
           storage_account_type = "StandardSSD_LRS"

--- a/templates/terraformer/gcp/nodepool/node.tpl
+++ b/templates/terraformer/gcp/nodepool/node.tpl
@@ -11,7 +11,7 @@
 {{- $specName       := $nodepool.Details.Provider.SpecName }}
 {{- $resourceSuffix := printf "%s_%s_%s" $region $specName $uniqueFingerPrint }}
 
-    {{- range $nodeIndex, $node := $nodepool.Nodes }}
+    {{- range $_, $node := $nodepool.Nodes }}
 
         {{- $computeExternalIpResourceName  := printf "%s_%s_external_ip" $node.Name $resourceSuffix }}
         {{- $computeExternalIpName          := printf "i%s" $node.Name }}
@@ -32,7 +32,7 @@
         {{- if $nodepool.Details.Zone }}
           zone                      = "{{ $nodepool.Details.Zone }}"
         {{- else }}
-          zone                      = element(data.google_compute_zones.available_{{ $resourceSuffix }}.names, parseint(regex("[0-9a-f]+$", "{{ $node.Name }}"), 16) % length(data.google_compute_zones.available_{{ $resourceSuffix }}.names))
+          zone                      = element(data.google_compute_zones.available_{{ $resourceSuffix }}.names, parseint(regex("[0-9a-f]+$", "{{ $node.Name }}"), 16))
         {{- end }}
           name                      = "{{ $node.Name }}"
           machine_type              = "{{ $nodepool.Details.ServerType }}"
@@ -168,7 +168,7 @@ EOF
             {{- if $nodepool.Details.Zone }}
               zone     = "{{ $nodepool.Details.Zone }}"
             {{- else }}
-              zone     = element(data.google_compute_zones.available_{{ $resourceSuffix }}.names, parseint(regex("[0-9a-f]+$", "{{ $node.Name }}"), 16) % length(data.google_compute_zones.available_{{ $resourceSuffix }}.names))
+              zone     = element(data.google_compute_zones.available_{{ $resourceSuffix }}.names, parseint(regex("[0-9a-f]+$", "{{ $node.Name }}"), 16))
             {{- end }}
               size     = {{ $nodepool.Details.StorageDiskSize }}
 
@@ -185,7 +185,7 @@ EOF
             {{- if $nodepool.Details.Zone }}
               zone        = "{{ $nodepool.Details.Zone }}"
             {{- else }}
-              zone        = element(data.google_compute_zones.available_{{ $resourceSuffix }}.names, parseint(regex("[0-9a-f]+$", "{{ $node.Name }}"), 16) % length(data.google_compute_zones.available_{{ $resourceSuffix }}.names))
+              zone        = element(data.google_compute_zones.available_{{ $resourceSuffix }}.names, parseint(regex("[0-9a-f]+$", "{{ $node.Name }}"), 16))
             {{- end }}
               device_name = var.{{ $varStorageDiskName }}
             }

--- a/templates/terraformer/gcp/nodepool/node.tpl
+++ b/templates/terraformer/gcp/nodepool/node.tpl
@@ -32,7 +32,7 @@
         {{- if $nodepool.Details.Zone }}
           zone                      = "{{ $nodepool.Details.Zone }}"
         {{- else }}
-          zone                      = element(data.google_compute_zones.available_{{ $resourceSuffix }}.names, parseint(substr(md5("{{ $node.Name }}"), 0, 2), 16) % length(data.google_compute_zones.available_{{ $resourceSuffix }}.names))
+          zone                      = element(data.google_compute_zones.available_{{ $resourceSuffix }}.names, parseint(regex("[0-9a-f]+$", "{{ $node.Name }}"), 16) % length(data.google_compute_zones.available_{{ $resourceSuffix }}.names))
         {{- end }}
           name                      = "{{ $node.Name }}"
           machine_type              = "{{ $nodepool.Details.ServerType }}"
@@ -168,7 +168,7 @@ EOF
             {{- if $nodepool.Details.Zone }}
               zone     = "{{ $nodepool.Details.Zone }}"
             {{- else }}
-              zone     = element(data.google_compute_zones.available_{{ $resourceSuffix }}.names, parseint(substr(md5("{{ $node.Name }}"), 0, 2), 16) % length(data.google_compute_zones.available_{{ $resourceSuffix }}.names))
+              zone     = element(data.google_compute_zones.available_{{ $resourceSuffix }}.names, parseint(regex("[0-9a-f]+$", "{{ $node.Name }}"), 16) % length(data.google_compute_zones.available_{{ $resourceSuffix }}.names))
             {{- end }}
               size     = {{ $nodepool.Details.StorageDiskSize }}
 
@@ -185,7 +185,7 @@ EOF
             {{- if $nodepool.Details.Zone }}
               zone        = "{{ $nodepool.Details.Zone }}"
             {{- else }}
-              zone        = element(data.google_compute_zones.available_{{ $resourceSuffix }}.names, parseint(substr(md5("{{ $node.Name }}"), 0, 2), 16) % length(data.google_compute_zones.available_{{ $resourceSuffix }}.names))
+              zone        = element(data.google_compute_zones.available_{{ $resourceSuffix }}.names, parseint(regex("[0-9a-f]+$", "{{ $node.Name }}"), 16) % length(data.google_compute_zones.available_{{ $resourceSuffix }}.names))
             {{- end }}
               device_name = var.{{ $varStorageDiskName }}
             }

--- a/templates/terraformer/gcp/nodepool/node.tpl
+++ b/templates/terraformer/gcp/nodepool/node.tpl
@@ -32,7 +32,7 @@
         {{- if $nodepool.Details.Zone }}
           zone                      = "{{ $nodepool.Details.Zone }}"
         {{- else }}
-          zone                      = element(data.google_compute_zones.available_{{ $resourceSuffix }}.names, {{ $nodeIndex }} % length(data.google_compute_zones.available_{{ $resourceSuffix }}.names))
+          zone                      = element(data.google_compute_zones.available_{{ $resourceSuffix }}.names, parseint(substr(md5("{{ $node.Name }}"), 0, 2), 16) % length(data.google_compute_zones.available_{{ $resourceSuffix }}.names))
         {{- end }}
           name                      = "{{ $node.Name }}"
           machine_type              = "{{ $nodepool.Details.ServerType }}"
@@ -168,7 +168,7 @@ EOF
             {{- if $nodepool.Details.Zone }}
               zone     = "{{ $nodepool.Details.Zone }}"
             {{- else }}
-              zone     = element(data.google_compute_zones.available_{{ $resourceSuffix }}.names, {{ $nodeIndex }} % length(data.google_compute_zones.available_{{ $resourceSuffix }}.names))
+              zone     = element(data.google_compute_zones.available_{{ $resourceSuffix }}.names, parseint(substr(md5("{{ $node.Name }}"), 0, 2), 16) % length(data.google_compute_zones.available_{{ $resourceSuffix }}.names))
             {{- end }}
               size     = {{ $nodepool.Details.StorageDiskSize }}
 
@@ -185,7 +185,7 @@ EOF
             {{- if $nodepool.Details.Zone }}
               zone        = "{{ $nodepool.Details.Zone }}"
             {{- else }}
-              zone        = element(data.google_compute_zones.available_{{ $resourceSuffix }}.names, {{ $nodeIndex }} % length(data.google_compute_zones.available_{{ $resourceSuffix }}.names))
+              zone        = element(data.google_compute_zones.available_{{ $resourceSuffix }}.names, parseint(substr(md5("{{ $node.Name }}"), 0, 2), 16) % length(data.google_compute_zones.available_{{ $resourceSuffix }}.names))
             {{- end }}
               device_name = var.{{ $varStorageDiskName }}
             }

--- a/templates/terraformer/oci/nodepool/node.tpl
+++ b/templates/terraformer/oci/nodepool/node.tpl
@@ -25,7 +25,7 @@
         {{- if $nodepool.Details.Zone }}
           availability_domain = "{{ $nodepool.Details.Zone }}"
         {{- else }}
-          availability_domain = element(data.oci_identity_availability_domains.available_{{ $resourceSuffix }}.availability_domains, {{ $nodeIndex }} % length(data.oci_identity_availability_domains.available_{{ $resourceSuffix }}.availability_domains)).name
+          availability_domain = element(data.oci_identity_availability_domains.available_{{ $resourceSuffix }}.availability_domains, parseint(substr(md5("{{ $node.Name }}"), 0, 2), 16) % length(data.oci_identity_availability_domains.available_{{ $resourceSuffix }}.availability_domains)).name
         {{- end }}
           shape               = "{{ $nodepool.Details.ServerType }}"
           display_name        = "{{ $node.Name }}"
@@ -168,7 +168,7 @@
             {{- if $nodepool.Details.Zone }}
               availability_domain = "{{ $nodepool.Details.Zone }}"
             {{- else }}
-              availability_domain = element(data.oci_identity_availability_domains.available_{{ $resourceSuffix }}.availability_domains, {{ $nodeIndex }} % length(data.oci_identity_availability_domains.available_{{ $resourceSuffix }}.availability_domains)).name
+              availability_domain = element(data.oci_identity_availability_domains.available_{{ $resourceSuffix }}.availability_domains, parseint(substr(md5("{{ $node.Name }}"), 0, 2), 16) % length(data.oci_identity_availability_domains.available_{{ $resourceSuffix }}.availability_domains)).name
             {{- end }}
               size_in_gbs         = "{{ $nodepool.Details.StorageDiskSize }}"
               display_name        = "{{ $coreVolumeName }}"

--- a/templates/terraformer/oci/nodepool/node.tpl
+++ b/templates/terraformer/oci/nodepool/node.tpl
@@ -11,7 +11,7 @@
 {{- $specName       := $nodepool.Details.Provider.SpecName }}
 {{- $resourceSuffix := printf "%s_%s_%s" $region $specName $uniqueFingerPrint }}
 
-    {{- range $nodeIndex, $node := $nodepool.Nodes }}
+    {{- range $_, $node := $nodepool.Nodes }}
 
         {{- $coreInstanceResourceName     := printf "%s_%s" $node.Name $resourceSuffix }}
         {{- $coreSubnetResourceName       := printf "%s_%s_subnet" $nodepool.Name $resourceSuffix }}
@@ -25,7 +25,7 @@
         {{- if $nodepool.Details.Zone }}
           availability_domain = "{{ $nodepool.Details.Zone }}"
         {{- else }}
-          availability_domain = element(data.oci_identity_availability_domains.available_{{ $resourceSuffix }}.availability_domains, parseint(regex("[0-9a-f]+$", "{{ $node.Name }}"), 16) % length(data.oci_identity_availability_domains.available_{{ $resourceSuffix }}.availability_domains)).name
+          availability_domain = element(data.oci_identity_availability_domains.available_{{ $resourceSuffix }}.availability_domains, parseint(regex("[0-9a-f]+$", "{{ $node.Name }}"), 16)).name
         {{- end }}
           shape               = "{{ $nodepool.Details.ServerType }}"
           display_name        = "{{ $node.Name }}"
@@ -168,7 +168,7 @@
             {{- if $nodepool.Details.Zone }}
               availability_domain = "{{ $nodepool.Details.Zone }}"
             {{- else }}
-              availability_domain = element(data.oci_identity_availability_domains.available_{{ $resourceSuffix }}.availability_domains, parseint(regex("[0-9a-f]+$", "{{ $node.Name }}"), 16) % length(data.oci_identity_availability_domains.available_{{ $resourceSuffix }}.availability_domains)).name
+              availability_domain = element(data.oci_identity_availability_domains.available_{{ $resourceSuffix }}.availability_domains, parseint(regex("[0-9a-f]+$", "{{ $node.Name }}"), 16)).name
             {{- end }}
               size_in_gbs         = "{{ $nodepool.Details.StorageDiskSize }}"
               display_name        = "{{ $coreVolumeName }}"

--- a/templates/terraformer/oci/nodepool/node.tpl
+++ b/templates/terraformer/oci/nodepool/node.tpl
@@ -25,7 +25,7 @@
         {{- if $nodepool.Details.Zone }}
           availability_domain = "{{ $nodepool.Details.Zone }}"
         {{- else }}
-          availability_domain = element(data.oci_identity_availability_domains.available_{{ $resourceSuffix }}.availability_domains, parseint(substr(md5("{{ $node.Name }}"), 0, 2), 16) % length(data.oci_identity_availability_domains.available_{{ $resourceSuffix }}.availability_domains)).name
+          availability_domain = element(data.oci_identity_availability_domains.available_{{ $resourceSuffix }}.availability_domains, parseint(regex("[0-9a-f]+$", "{{ $node.Name }}"), 16) % length(data.oci_identity_availability_domains.available_{{ $resourceSuffix }}.availability_domains)).name
         {{- end }}
           shape               = "{{ $nodepool.Details.ServerType }}"
           display_name        = "{{ $node.Name }}"
@@ -168,7 +168,7 @@
             {{- if $nodepool.Details.Zone }}
               availability_domain = "{{ $nodepool.Details.Zone }}"
             {{- else }}
-              availability_domain = element(data.oci_identity_availability_domains.available_{{ $resourceSuffix }}.availability_domains, parseint(substr(md5("{{ $node.Name }}"), 0, 2), 16) % length(data.oci_identity_availability_domains.available_{{ $resourceSuffix }}.availability_domains)).name
+              availability_domain = element(data.oci_identity_availability_domains.available_{{ $resourceSuffix }}.availability_domains, parseint(regex("[0-9a-f]+$", "{{ $node.Name }}"), 16) % length(data.oci_identity_availability_domains.available_{{ $resourceSuffix }}.availability_domains)).name
             {{- end }}
               size_in_gbs         = "{{ $nodepool.Details.StorageDiskSize }}"
               display_name        = "{{ $coreVolumeName }}"


### PR DESCRIPTION
## Summary
- Replaces index-based zone distribution (`$nodeIndex % zone_count`) with deterministic node-name-based distribution (`parseint(regex("[0-9a-f]+$", node_name), 16)`) across all providers (AWS, Azure, GCP, OCI)
- Fixes zone reassignment when nodes are added/removed by the autoscaler — previously, adding or removing a node would shift all subsequent node indices, causing existing nodes to be reassigned to different zones and triggering unnecessary recreation
- Removes redundant `% length(...)` in `element()` calls — `element()` already wraps the index internally
- Replaces unused `$nodeIndex` with `$_` in range loops
- Uses stable node name suffix for AWS `cidrsubnet` calculation with `$maxSubnets` to keep the subnet number in range

## Affected providers
- **AWS**: instance + EBS volume + subnet availability zone + subnet CIDR
- **Azure**: VM + managed disk zone
- **GCP**: compute instance + disk + attached disk zone
- **OCI**: instance + block volume availability domain

## Test plan
- [x] Deploy GCP cluster with autoscaler (`min: 1, max: 10`), zone omitted
- [x] Trigger scale-up (1 → 3 workers) — nodes distributed across zones (europe-west1-c, europe-west1-d, europe-west1-b)
- [x] Scale down (3 → 2 → 1) — remaining nodes kept their original zone assignments
- [x] Deploy AWS cluster with autoscaler (`min: 1, max: 10`), zone omitted
- [x] Trigger scale-up (1 → 3 workers) — nodes distributed across AZs, longhorn healthy on all nodes
- [x] Zone assignment is deterministic based on node name hex suffix, stable across reconciliation cycles