### PR TITLE
Custom SSH port for nodepools (old=22, new=22522)

### DIFF
--- a/templates/terraformer/aws/networking/networking.tpl
+++ b/templates/terraformer/aws/networking/networking.tpl
@@ -96,6 +96,16 @@ resource "aws_security_group_rule" "allow_ssh_{{ $resourceSuffix }}" {
   security_group_id = aws_security_group.{{ $securityGroupResourceName }}.id
 }
 
+resource "aws_security_group_rule" "allow_ssh_22522_{{ $resourceSuffix }}" {
+  provider          = aws.nodepool_{{ $resourceSuffix }}
+  type              = "ingress"
+  from_port         = 22522
+  to_port           = 22522
+  protocol          = "tcp"
+  cidr_blocks       = ["0.0.0.0/0"]
+  security_group_id = aws_security_group.{{ $securityGroupResourceName }}.id
+}
+
 {{- if $isKubernetesCluster  }}
     {{- if $K8sHasAPIServer }}
 resource "aws_security_group_rule" "allow_kube_api_{{ $resourceSuffix }}" {

--- a/templates/terraformer/aws/networking/networking.tpl
+++ b/templates/terraformer/aws/networking/networking.tpl
@@ -85,7 +85,8 @@ resource "aws_security_group_rule" "allow_egress_{{ $resourceSuffix }}" {
   security_group_id = aws_security_group.{{ $securityGroupResourceName }}.id
 }
 
-resource "aws_security_group_rule" "allow_ssh_{{ $resourceSuffix }}" {
+{{- range $port := $.Data.SshPorts }}
+resource "aws_security_group_rule" "allow_ssh_{{ $port }}_{{ $resourceSuffix }}" {
   provider          = aws.nodepool_{{ $resourceSuffix }}
   type              = "ingress"
   from_port         = {{ $port }}
@@ -94,6 +95,7 @@ resource "aws_security_group_rule" "allow_ssh_{{ $resourceSuffix }}" {
   cidr_blocks       = ["0.0.0.0/0"]
   security_group_id = aws_security_group.{{ $securityGroupResourceName }}.id
 }
+{{- end }}
 
 {{- if $isKubernetesCluster  }}
     {{- if $K8sHasAPIServer }}

--- a/templates/terraformer/aws/networking/networking.tpl
+++ b/templates/terraformer/aws/networking/networking.tpl
@@ -86,25 +86,17 @@ resource "aws_security_group_rule" "allow_egress_{{ $resourceSuffix }}" {
 }
 
 
-resource "aws_security_group_rule" "allow_ssh_{{ $resourceSuffix }}" {
+{{- range $port := .Data.SshPorts }}
+resource "aws_security_group_rule" "allow_ssh_{{ $port }}_{{ $resourceSuffix }}" {
   provider          = aws.nodepool_{{ $resourceSuffix }}
   type              = "ingress"
-  from_port         = 22
-  to_port           = 22
+  from_port         = {{ $port }}
+  to_port           = {{ $port }}
   protocol          = "tcp"
   cidr_blocks       = ["0.0.0.0/0"]
   security_group_id = aws_security_group.{{ $securityGroupResourceName }}.id
 }
-
-resource "aws_security_group_rule" "allow_ssh_22522_{{ $resourceSuffix }}" {
-  provider          = aws.nodepool_{{ $resourceSuffix }}
-  type              = "ingress"
-  from_port         = 22522
-  to_port           = 22522
-  protocol          = "tcp"
-  cidr_blocks       = ["0.0.0.0/0"]
-  security_group_id = aws_security_group.{{ $securityGroupResourceName }}.id
-}
+{{- end }}
 
 {{- if $isKubernetesCluster  }}
     {{- if $K8sHasAPIServer }}

--- a/templates/terraformer/aws/networking/networking.tpl
+++ b/templates/terraformer/aws/networking/networking.tpl
@@ -85,9 +85,7 @@ resource "aws_security_group_rule" "allow_egress_{{ $resourceSuffix }}" {
   security_group_id = aws_security_group.{{ $securityGroupResourceName }}.id
 }
 
-
-{{- range $port := $.Data.SshPorts }}
-resource "aws_security_group_rule" "allow_ssh_{{ $port }}_{{ $resourceSuffix }}" {
+resource "aws_security_group_rule" "allow_ssh_{{ $resourceSuffix }}" {
   provider          = aws.nodepool_{{ $resourceSuffix }}
   type              = "ingress"
   from_port         = {{ $port }}
@@ -96,7 +94,6 @@ resource "aws_security_group_rule" "allow_ssh_{{ $port }}_{{ $resourceSuffix }}"
   cidr_blocks       = ["0.0.0.0/0"]
   security_group_id = aws_security_group.{{ $securityGroupResourceName }}.id
 }
-{{- end }}
 
 {{- if $isKubernetesCluster  }}
     {{- if $K8sHasAPIServer }}

--- a/templates/terraformer/aws/networking/networking.tpl
+++ b/templates/terraformer/aws/networking/networking.tpl
@@ -86,7 +86,7 @@ resource "aws_security_group_rule" "allow_egress_{{ $resourceSuffix }}" {
 }
 
 
-{{- range $port := .Data.SshPorts }}
+{{- range $port := $.Data.SshPorts }}
 resource "aws_security_group_rule" "allow_ssh_{{ $port }}_{{ $resourceSuffix }}" {
   provider          = aws.nodepool_{{ $resourceSuffix }}
   type              = "ingress"

--- a/templates/terraformer/aws/nodepool/node.tpl
+++ b/templates/terraformer/aws/nodepool/node.tpl
@@ -132,38 +132,48 @@ resource "aws_key_pair" "{{ $keypairResourceName }}" {
             delete_on_termination = true
             volume_type           = "gp2"
           }
-          user_data = <<EOF
-#!/bin/bash
-set -euxo pipefail
-# Allow ssh connection for root
-sed -n 's/^.*ssh-rsa/ssh-rsa/p' /root/.ssh/authorized_keys > /root/.ssh/temp
-cat /root/.ssh/temp > /root/.ssh/authorized_keys
-rm /root/.ssh/temp
-echo 'PermitRootLogin without-password' >> /etc/ssh/sshd_config && echo 'PubkeyAuthentication yes' >> /etc/ssh/sshd_config && echo "PubkeyAcceptedKeyTypes=+ssh-rsa" >> sshd_config
+          {{- if ne $nodepool.SshPort 22 }}
+            user_data = <<-EOF
+              #!/bin/bash
+              # Allow ssh connection for root
+              sed -n 's/^.*ssh-rsa/ssh-rsa/p' /root/.ssh/authorized_keys > /root/.ssh/temp
+              cat /root/.ssh/temp > /root/.ssh/authorized_keys
+              rm /root/.ssh/temp
+              echo 'PermitRootLogin without-password' >> /etc/ssh/sshd_config && echo 'PubkeyAuthentication yes' >> /etc/ssh/sshd_config && echo "PubkeyAcceptedKeyTypes=+ssh-rsa" >> /etc/ssh/sshd_config
 
-if [ "{{ $nodepool.SshPort }}" != "22" ]; then
-  # Configure custom SSH port in sshd_config (for non-socket-activated systems)
-  echo "Port {{ $nodepool.SshPort }}" >> /etc/ssh/sshd_config
-  mkdir -p /etc/systemd/system/ssh.socket.d/
-  cat > /etc/systemd/system/ssh.socket.d/override.conf <<OVERRIDE
-[Socket]
-ListenStream=
-ListenStream=0.0.0.0:{{ $nodepool.SshPort }}
-OVERRIDE
-    systemctl daemon-reload
-    systemctl restart ssh.socket
-else
-    # Traditional sshd
-    sshd_active=$(systemctl is-active sshd 2>/dev/null || true)
-    ssh_active=$(systemctl is-active ssh 2>/dev/null || true)
-    if [ "$sshd_active" = "active" ]; then
-        systemctl restart sshd
-    fi
-    if [ "$ssh_active" = "active" ]; then
-        systemctl restart ssh
-    fi
-fi
-EOF
+              # Configure custom SSH port in sshd_config (for non-socket-activated systems)
+              echo "Port {{ $nodepool.SshPort }}" >> /etc/ssh/sshd_config
+              mkdir -p /etc/systemd/system/ssh.socket.d/
+              cat > /etc/systemd/system/ssh.socket.d/override.conf <<OVERRIDE
+              [Socket]
+              ListenStream=
+              ListenStream=0.0.0.0:{{ $nodepool.SshPort }}
+              OVERRIDE
+              systemctl daemon-reload
+              systemctl restart ssh.socket
+              EOF
+          {{- else }}
+            user_data = <<-EOF
+              #!/bin/bash
+              # Allow ssh connection for root
+              sed -n 's/^.*ssh-rsa/ssh-rsa/p' /root/.ssh/authorized_keys > /root/.ssh/temp
+              cat /root/.ssh/temp > /root/.ssh/authorized_keys
+              rm /root/.ssh/temp
+              echo 'PermitRootLogin without-password' >> /etc/ssh/sshd_config && echo 'PubkeyAuthentication yes' >> /etc/ssh/sshd_config && echo "PubkeyAcceptedKeyTypes=+ssh-rsa" >> /etc/ssh/sshd_config
+
+              # Traditional sshd
+              sshd_active=$(systemctl is-active sshd 2>/dev/null || true)
+              ssh_active=$(systemctl is-active ssh 2>/dev/null || true)
+              if [ "$sshd_active" = "active" ]; then
+                  systemctl restart sshd
+              fi
+              if [ "$ssh_active" = "active" ]; then
+                  systemctl restart ssh
+              fi
+              EOF
+          {{- end }}
+        {{- end }}
+        
 # Create longhorn volume directory
 mkdir -p /opt/claudie/data
 

--- a/templates/terraformer/aws/nodepool/node.tpl
+++ b/templates/terraformer/aws/nodepool/node.tpl
@@ -90,7 +90,7 @@ resource "aws_key_pair" "{{ $keypairResourceName }}" {
 sed -n 's/^.*ssh-rsa/ssh-rsa/p' /root/.ssh/authorized_keys > /root/.ssh/temp
 cat /root/.ssh/temp > /root/.ssh/authorized_keys
 rm /root/.ssh/temp
-echo 'Port 2222' >> /etc/ssh/sshd_config && echo 'PermitRootLogin without-password' >> /etc/ssh/sshd_config && echo 'PubkeyAuthentication yes' >> /etc/ssh/sshd_config && echo "PubkeyAcceptedKeyTypes=+ssh-rsa" >> sshd_config
+echo 'PermitRootLogin without-password' >> /etc/ssh/sshd_config && echo 'PubkeyAuthentication yes' >> /etc/ssh/sshd_config && echo "PubkeyAcceptedKeyTypes=+ssh-rsa" >> sshd_config
 # The '|| true' part in the following cmd makes sure that this script doesn't fail when there is no sshd service.
 sshd_active=$(systemctl is-active sshd 2>/dev/null || true)
 ssh_active=$(systemctl is-active ssh 2>/dev/null || true)

--- a/templates/terraformer/aws/nodepool/node.tpl
+++ b/templates/terraformer/aws/nodepool/node.tpl
@@ -91,20 +91,31 @@ sed -n 's/^.*ssh-rsa/ssh-rsa/p' /root/.ssh/authorized_keys > /root/.ssh/temp
 cat /root/.ssh/temp > /root/.ssh/authorized_keys
 rm /root/.ssh/temp
 echo 'PermitRootLogin without-password' >> /etc/ssh/sshd_config && echo 'PubkeyAuthentication yes' >> /etc/ssh/sshd_config && echo "PubkeyAcceptedKeyTypes=+ssh-rsa" >> sshd_config
-# Configure custom SSH port
+
+# Configure custom SSH port in sshd_config (for non-socket-activated systems)
 echo "Port {{ $nodepool.SshPort }}" >> /etc/ssh/sshd_config
-# Need to daemon reload after ssh port changes
-systemctl daemon-reload
-# The '|| true' part in the following cmd makes sure that this script doesn't fail when there is no sshd service.
-sshd_active=$(systemctl is-active sshd 2>/dev/null || true)
-ssh_active=$(systemctl is-active ssh 2>/dev/null || true)
 
-if [ $sshd_active = 'active' ]; then
-    systemctl restart sshd
-fi
-
-if [ $ssh_active = 'active' ]; then
-    systemctl restart ssh
+# Override socket unit if socket-activated SSH is present
+if systemctl list-unit-files ssh.socket &>/dev/null; then
+    mkdir -p /etc/systemd/system/ssh.socket.d/
+    cat > /etc/systemd/system/ssh.socket.d/override.conf <<OVERRIDE
+[Socket]
+ListenStream=
+ListenStream=[::]:{{ $nodepool.SshPort }}
+ListenStream=0.0.0.0:{{ $nodepool.SshPort }}
+OVERRIDE
+    systemctl daemon-reload
+    systemctl restart ssh.socket
+else
+    # Traditional sshd — just restart
+    sshd_active=$(systemctl is-active sshd 2>/dev/null || true)
+    ssh_active=$(systemctl is-active ssh 2>/dev/null || true)
+    if [ "$sshd_active" = "active" ]; then
+        systemctl restart sshd
+    fi
+    if [ "$ssh_active" = "active" ]; then
+        systemctl restart ssh
+    fi
 fi
 EOF
 
@@ -124,20 +135,31 @@ sed -n 's/^.*ssh-rsa/ssh-rsa/p' /root/.ssh/authorized_keys > /root/.ssh/temp
 cat /root/.ssh/temp > /root/.ssh/authorized_keys
 rm /root/.ssh/temp
 echo 'PermitRootLogin without-password' >> /etc/ssh/sshd_config && echo 'PubkeyAuthentication yes' >> /etc/ssh/sshd_config && echo "PubkeyAcceptedKeyTypes=+ssh-rsa" >> sshd_config
-# Configure custom SSH port
+
+# Configure custom SSH port in sshd_config (for non-socket-activated systems)
 echo "Port {{ $nodepool.SshPort }}" >> /etc/ssh/sshd_config
-# Need to daemon reload after ssh port changes
-systemctl daemon-reload
-# The '|| true' part in the following cmd makes sure that this script doesn't fail when there is no sshd service.
-sshd_active=$(systemctl is-active sshd 2>/dev/null || true)
-ssh_active=$(systemctl is-active ssh 2>/dev/null || true)
 
-if [ $sshd_active = 'active' ]; then
-    systemctl restart sshd
-fi
-
-if [ $ssh_active = 'active' ]; then
-    systemctl restart ssh
+# Override socket unit if socket-activated SSH is present
+if systemctl list-unit-files ssh.socket &>/dev/null; then
+    mkdir -p /etc/systemd/system/ssh.socket.d/
+    cat > /etc/systemd/system/ssh.socket.d/override.conf <<OVERRIDE
+[Socket]
+ListenStream=
+ListenStream=[::]:{{ $nodepool.SshPort }}
+ListenStream=0.0.0.0:{{ $nodepool.SshPort }}
+OVERRIDE
+    systemctl daemon-reload
+    systemctl restart ssh.socket
+else
+    # Traditional sshd — just restart
+    sshd_active=$(systemctl is-active sshd 2>/dev/null || true)
+    ssh_active=$(systemctl is-active ssh 2>/dev/null || true)
+    if [ "$sshd_active" = "active" ]; then
+        systemctl restart sshd
+    fi
+    if [ "$ssh_active" = "active" ]; then
+        systemctl restart ssh
+    fi
 fi
 # Create longhorn volume directory
 mkdir -p /opt/claudie/data

--- a/templates/terraformer/aws/nodepool/node.tpl
+++ b/templates/terraformer/aws/nodepool/node.tpl
@@ -218,7 +218,7 @@ output  "{{ $nodepool.Name }}_{{ $specName }}_{{ $uniqueFingerPrint }}" {
     {{- range $_, $node := $nodepool.Nodes }}
         {{- $instanceResourceName := printf "%s_%s" $node.Name $resourceSuffix }}
         {{- $eipResourceName := printf "%s_%s_eip" $node.Name $resourceSuffix }}
-        "${aws_instance.{{ $instanceResourceName }}.tags_all.Name}" = aws_eip.{{ $eipResourceName }}.public_ip
+        "${aws_instance.{{ $instanceResourceName }}.tags_all.Name}" = [aws_eip.{{ $eipResourceName }}.public_ip, "{{ $nodepool.SshPort }}"]
     {{- end }}
   }
 }

--- a/templates/terraformer/aws/nodepool/node.tpl
+++ b/templates/terraformer/aws/nodepool/node.tpl
@@ -232,7 +232,7 @@ output  "{{ $nodepool.Name }}_{{ $specName }}_{{ $uniqueFingerPrint }}" {
     {{- range $_, $node := $nodepool.Nodes }}
         {{- $instanceResourceName := printf "%s_%s" $node.Name $resourceSuffix }}
         {{- $eipResourceName := printf "%s_%s_eip" $node.Name $resourceSuffix }}
-        "${aws_instance.{{ $instanceResourceName }}.tags_all.Name}" = [aws_eip.{{ $eipResourceName }}.public_ip, "{{ $nodepool.SshPort }}"]
+        "${aws_instance.{{ $instanceResourceName }}.tags_all.Name}" = aws_eip.{{ $eipResourceName }}.public_ip
     {{- end }}
   }
 }

--- a/templates/terraformer/aws/nodepool/node.tpl
+++ b/templates/terraformer/aws/nodepool/node.tpl
@@ -92,7 +92,7 @@ cat /root/.ssh/temp > /root/.ssh/authorized_keys
 rm /root/.ssh/temp
 echo 'PermitRootLogin without-password' >> /etc/ssh/sshd_config && echo 'PubkeyAuthentication yes' >> /etc/ssh/sshd_config && echo "PubkeyAcceptedKeyTypes=+ssh-rsa" >> sshd_config
 
-if "{{ $nodepool.SshPort }}" != "22"; then
+if [ "{{ $nodepool.SshPort }}" != "22" ]; then
   # Configure custom SSH port in sshd_config (for non-socket-activated systems)
   echo "Port {{ $nodepool.SshPort }}" >> /etc/ssh/sshd_config
   mkdir -p /etc/systemd/system/ssh.socket.d/
@@ -133,7 +133,7 @@ cat /root/.ssh/temp > /root/.ssh/authorized_keys
 rm /root/.ssh/temp
 echo 'PermitRootLogin without-password' >> /etc/ssh/sshd_config && echo 'PubkeyAuthentication yes' >> /etc/ssh/sshd_config && echo "PubkeyAcceptedKeyTypes=+ssh-rsa" >> sshd_config
 
-if "{{ $nodepool.SshPort }}" != "22"; then
+if [ "{{ $nodepool.SshPort }}" != "22" ]; then
   # Configure custom SSH port in sshd_config (for non-socket-activated systems)
   echo "Port {{ $nodepool.SshPort }}" >> /etc/ssh/sshd_config
   mkdir -p /etc/systemd/system/ssh.socket.d/

--- a/templates/terraformer/aws/nodepool/node.tpl
+++ b/templates/terraformer/aws/nodepool/node.tpl
@@ -85,44 +85,42 @@ resource "aws_key_pair" "{{ $keypairResourceName }}" {
           }
 
           {{- if ne $nodepool.SshPort 22 }}
-            user_data = <<-EOF
-              #!/bin/bash
-              # Allow ssh connection for root
-              sed -n 's/^.*ssh-rsa/ssh-rsa/p' /root/.ssh/authorized_keys > /root/.ssh/temp
-              cat /root/.ssh/temp > /root/.ssh/authorized_keys
-              rm /root/.ssh/temp
-              echo 'PermitRootLogin without-password' >> /etc/ssh/sshd_config && echo 'PubkeyAuthentication yes' >> /etc/ssh/sshd_config && echo "PubkeyAcceptedKeyTypes=+ssh-rsa" >> /etc/ssh/sshd_config
-
-              # Configure custom SSH port in sshd_config (for non-socket-activated systems)
-              echo "Port {{ $nodepool.SshPort }}" >> /etc/ssh/sshd_config
-              mkdir -p /etc/systemd/system/ssh.socket.d/
-              cat > /etc/systemd/system/ssh.socket.d/override.conf <<-OVERRIDE
-              [Socket]
-              ListenStream=
-              ListenStream=0.0.0.0:{{ $nodepool.SshPort }}
-              OVERRIDE
-              systemctl daemon-reload
-              systemctl restart ssh.socket
-              EOF
+            user_data = <<EOF
+#!/bin/bash
+# Allow ssh connection for root
+sed -n 's/^.*ssh-rsa/ssh-rsa/p' /root/.ssh/authorized_keys > /root/.ssh/temp
+cat /root/.ssh/temp > /root/.ssh/authorized_keys
+rm /root/.ssh/temp
+echo 'PermitRootLogin without-password' >> /etc/ssh/sshd_config && echo 'PubkeyAuthentication yes' >> /etc/ssh/sshd_config && echo "PubkeyAcceptedKeyTypes=+ssh-rsa" >> /etc/ssh/sshd_
+# Configure custom SSH port in sshd_config (for non-socket-activated systems)
+echo "Port {{ $nodepool.SshPort }}" >> /etc/ssh/sshd_config
+mkdir -p /etc/systemd/system/ssh.socket.d/
+cat > /etc/systemd/system/ssh.socket.d/override.conf <<-OVERRIDE
+[Socket]
+ListenStream=
+ListenStream=0.0.0.0:{{ $nodepool.SshPort }}
+OVERRIDE
+systemctl daemon-reload
+systemctl restart ssh.socket
+EOF
           {{- else }}
             user_data = <<-EOF
-              #!/bin/bash
-              # Allow ssh connection for root
-              sed -n 's/^.*ssh-rsa/ssh-rsa/p' /root/.ssh/authorized_keys > /root/.ssh/temp
-              cat /root/.ssh/temp > /root/.ssh/authorized_keys
-              rm /root/.ssh/temp
-              echo 'PermitRootLogin without-password' >> /etc/ssh/sshd_config && echo 'PubkeyAuthentication yes' >> /etc/ssh/sshd_config && echo "PubkeyAcceptedKeyTypes=+ssh-rsa" >> /etc/ssh/sshd_config
-
-              # Traditional sshd
-              sshd_active=$(systemctl is-active sshd 2>/dev/null || true)
-              ssh_active=$(systemctl is-active ssh 2>/dev/null || true)
-              if [ "$sshd_active" = "active" ]; then
-                  systemctl restart sshd
-              fi
-              if [ "$ssh_active" = "active" ]; then
-                  systemctl restart ssh
-              fi
-              EOF
+#!/bin/bash
+# Allow ssh connection for root
+sed -n 's/^.*ssh-rsa/ssh-rsa/p' /root/.ssh/authorized_keys > /root/.ssh/temp
+cat /root/.ssh/temp > /root/.ssh/authorized_keys
+rm /root/.ssh/temp
+echo 'PermitRootLogin without-password' >> /etc/ssh/sshd_config && echo 'PubkeyAuthentication yes' >> /etc/ssh/sshd_config && echo "PubkeyAcceptedKeyTypes=+ssh-rsa" >> /etc/ssh/sshd_config
+# Traditional sshd
+sshd_active=$(systemctl is-active sshd 2>/dev/null || true)
+ssh_active=$(systemctl is-active ssh 2>/dev/null || true)
+if [ "$sshd_active" = "active" ]; then
+    systemctl restart sshd
+fi
+if [ "$ssh_active" = "active" ]; then
+    systemctl restart ssh
+fi
+EOF
           {{- end }}
         {{- end }}
 
@@ -134,47 +132,45 @@ resource "aws_key_pair" "{{ $keypairResourceName }}" {
           }
           {{- if ne $nodepool.SshPort 22 }}
             user_data = <<-EOF
-              #!/bin/bash
-              # Allow ssh connection for root
-              sed -n 's/^.*ssh-rsa/ssh-rsa/p' /root/.ssh/authorized_keys > /root/.ssh/temp
-              cat /root/.ssh/temp > /root/.ssh/authorized_keys
-              rm /root/.ssh/temp
-              echo 'PermitRootLogin without-password' >> /etc/ssh/sshd_config && echo 'PubkeyAuthentication yes' >> /etc/ssh/sshd_config && echo "PubkeyAcceptedKeyTypes=+ssh-rsa" >> /etc/ssh/sshd_config
-
-              # Configure custom SSH port in sshd_config (for non-socket-activated systems)
-              echo "Port {{ $nodepool.SshPort }}" >> /etc/ssh/sshd_config
-              mkdir -p /etc/systemd/system/ssh.socket.d/
-              cat > /etc/systemd/system/ssh.socket.d/override.conf <<-OVERRIDE
-              [Socket]
-              ListenStream=
-              ListenStream=0.0.0.0:{{ $nodepool.SshPort }}
-              OVERRIDE
-              systemctl daemon-reload
-              systemctl restart ssh.socket
+#!/bin/bash
+# Allow ssh connection for root
+sed -n 's/^.*ssh-rsa/ssh-rsa/p' /root/.ssh/authorized_keys > /root/.ssh/temp
+cat /root/.ssh/temp > /root/.ssh/authorized_keys
+rm /root/.ssh/temp
+echo 'PermitRootLogin without-password' >> /etc/ssh/sshd_config && echo 'PubkeyAuthentication yes' >> /etc/ssh/sshd_config && echo "PubkeyAcceptedKeyTypes=+ssh-rsa" >> /etc/ssh/sshd_config
+# Configure custom SSH port in sshd_config (for non-socket-activated systems)
+echo "Port {{ $nodepool.SshPort }}" >> /etc/ssh/sshd_config
+mkdir -p /etc/systemd/system/ssh.socket.d/
+cat > /etc/systemd/system/ssh.socket.d/override.conf <<-OVERRIDE
+[Socket]
+ListenStream=
+ListenStream=0.0.0.0:{{ $nodepool.SshPort }}
+OVERRIDE
+systemctl daemon-reload
+systemctl restart ssh.socket
               
           {{- else }}
             user_data = <<-EOF
-              #!/bin/bash
-              # Allow ssh connection for root
-              sed -n 's/^.*ssh-rsa/ssh-rsa/p' /root/.ssh/authorized_keys > /root/.ssh/temp
-              cat /root/.ssh/temp > /root/.ssh/authorized_keys
-              rm /root/.ssh/temp
-              echo 'PermitRootLogin without-password' >> /etc/ssh/sshd_config && echo 'PubkeyAuthentication yes' >> /etc/ssh/sshd_config && echo "PubkeyAcceptedKeyTypes=+ssh-rsa" >> /etc/ssh/sshd_config
-
-              # Traditional sshd
-              sshd_active=$(systemctl is-active sshd 2>/dev/null || true)
-              ssh_active=$(systemctl is-active ssh 2>/dev/null || true)
-              if [ "$sshd_active" = "active" ]; then
-                  systemctl restart sshd
-              fi
-              if [ "$ssh_active" = "active" ]; then
-                  systemctl restart ssh
-              fi
+#!/bin/bash
+# Allow ssh connection for root
+sed -n 's/^.*ssh-rsa/ssh-rsa/p' /root/.ssh/authorized_keys > /root/.ssh/temp
+cat /root/.ssh/temp > /root/.ssh/authorized_keys
+rm /root/.ssh/temp
+echo 'PermitRootLogin without-password' >> /etc/ssh/sshd_config && echo 'PubkeyAuthentication yes' >> /etc/ssh/sshd_config && echo "PubkeyAcceptedKeyTypes=+ssh-rsa" >> /etc/ssh/sshd_config
+# Traditional sshd
+sshd_active=$(systemctl is-active sshd 2>/dev/null || true)
+ssh_active=$(systemctl is-active ssh 2>/dev/null || true)
+if [ "$sshd_active" = "active" ]; then
+    systemctl restart sshd
+fi
+if [ "$ssh_active" = "active" ]; then
+    systemctl restart ssh
+fi
               
           {{- end }}
 
-          # Create longhorn volume directory
-          mkdir -p /opt/claudie/data
+# Create longhorn volume directory
+mkdir -p /opt/claudie/data
 
           {{- if $isWorkerNodeWithDiskAttached }}
 

--- a/templates/terraformer/aws/nodepool/node.tpl
+++ b/templates/terraformer/aws/nodepool/node.tpl
@@ -90,7 +90,7 @@ resource "aws_key_pair" "{{ $keypairResourceName }}" {
 sed -n 's/^.*ssh-rsa/ssh-rsa/p' /root/.ssh/authorized_keys > /root/.ssh/temp
 cat /root/.ssh/temp > /root/.ssh/authorized_keys
 rm /root/.ssh/temp
-echo 'PermitRootLogin without-password' >> /etc/ssh/sshd_config && echo 'PubkeyAuthentication yes' >> /etc/ssh/sshd_config && echo "PubkeyAcceptedKeyTypes=+ssh-rsa" >> sshd_config
+echo 'Port 2222' >> /etc/ssh/sshd_config && echo 'PermitRootLogin without-password' >> /etc/ssh/sshd_config && echo 'PubkeyAuthentication yes' >> /etc/ssh/sshd_config && echo "PubkeyAcceptedKeyTypes=+ssh-rsa" >> sshd_config
 # The '|| true' part in the following cmd makes sure that this script doesn't fail when there is no sshd service.
 sshd_active=$(systemctl is-active sshd 2>/dev/null || true)
 ssh_active=$(systemctl is-active ssh 2>/dev/null || true)

--- a/templates/terraformer/aws/nodepool/node.tpl
+++ b/templates/terraformer/aws/nodepool/node.tpl
@@ -92,13 +92,11 @@ cat /root/.ssh/temp > /root/.ssh/authorized_keys
 rm /root/.ssh/temp
 echo 'PermitRootLogin without-password' >> /etc/ssh/sshd_config && echo 'PubkeyAuthentication yes' >> /etc/ssh/sshd_config && echo "PubkeyAcceptedKeyTypes=+ssh-rsa" >> sshd_config
 
-# Configure custom SSH port in sshd_config (for non-socket-activated systems)
-echo "Port {{ $nodepool.SshPort }}" >> /etc/ssh/sshd_config
-
-# Override socket unit if socket-activated SSH is present
-if systemctl list-unit-files ssh.socket &>/dev/null; then
-    mkdir -p /etc/systemd/system/ssh.socket.d/
-    cat > /etc/systemd/system/ssh.socket.d/override.conf <<OVERRIDE
+if "{{ $nodepool.SshPort }}" != "22"; then
+  # Configure custom SSH port in sshd_config (for non-socket-activated systems)
+  echo "Port {{ $nodepool.SshPort }}" >> /etc/ssh/sshd_config
+  mkdir -p /etc/systemd/system/ssh.socket.d/
+  cat > /etc/systemd/system/ssh.socket.d/override.conf <<OVERRIDE
 [Socket]
 ListenStream=
 ListenStream=0.0.0.0:{{ $nodepool.SshPort }}
@@ -135,13 +133,11 @@ cat /root/.ssh/temp > /root/.ssh/authorized_keys
 rm /root/.ssh/temp
 echo 'PermitRootLogin without-password' >> /etc/ssh/sshd_config && echo 'PubkeyAuthentication yes' >> /etc/ssh/sshd_config && echo "PubkeyAcceptedKeyTypes=+ssh-rsa" >> sshd_config
 
-# Configure custom SSH port in sshd_config (for non-socket-activated systems)
-echo "Port {{ $nodepool.SshPort }}" >> /etc/ssh/sshd_config
-
-# Override socket unit if socket-activated SSH is present
-if systemctl list-unit-files ssh.socket &>/dev/null; then
-    mkdir -p /etc/systemd/system/ssh.socket.d/
-    cat > /etc/systemd/system/ssh.socket.d/override.conf <<OVERRIDE
+if "{{ $nodepool.SshPort }}" != "22"; then
+  # Configure custom SSH port in sshd_config (for non-socket-activated systems)
+  echo "Port {{ $nodepool.SshPort }}" >> /etc/ssh/sshd_config
+  mkdir -p /etc/systemd/system/ssh.socket.d/
+  cat > /etc/systemd/system/ssh.socket.d/override.conf <<OVERRIDE
 [Socket]
 ListenStream=
 ListenStream=0.0.0.0:{{ $nodepool.SshPort }}
@@ -159,6 +155,7 @@ else
         systemctl restart ssh
     fi
 fi
+EOF
 # Create longhorn volume directory
 mkdir -p /opt/claudie/data
 

--- a/templates/terraformer/aws/nodepool/node.tpl
+++ b/templates/terraformer/aws/nodepool/node.tpl
@@ -84,38 +84,46 @@ resource "aws_key_pair" "{{ $keypairResourceName }}" {
             volume_type           = "gp2"
           }
 
-          user_data = <<EOF
-#!/bin/bash
-# Allow ssh connection for root
-sed -n 's/^.*ssh-rsa/ssh-rsa/p' /root/.ssh/authorized_keys > /root/.ssh/temp
-cat /root/.ssh/temp > /root/.ssh/authorized_keys
-rm /root/.ssh/temp
-echo 'PermitRootLogin without-password' >> /etc/ssh/sshd_config && echo 'PubkeyAuthentication yes' >> /etc/ssh/sshd_config && echo "PubkeyAcceptedKeyTypes=+ssh-rsa" >> sshd_config
+          {{- if ne $nodepool.SshPort 22 }}
+            user_data = <<-EOF
+              #!/bin/bash
+              # Allow ssh connection for root
+              sed -n 's/^.*ssh-rsa/ssh-rsa/p' /root/.ssh/authorized_keys > /root/.ssh/temp
+              cat /root/.ssh/temp > /root/.ssh/authorized_keys
+              rm /root/.ssh/temp
+              echo 'PermitRootLogin without-password' >> /etc/ssh/sshd_config && echo 'PubkeyAuthentication yes' >> /etc/ssh/sshd_config && echo "PubkeyAcceptedKeyTypes=+ssh-rsa" >> /etc/ssh/sshd_config
 
-if [ "{{ $nodepool.SshPort }}" != "22" ]; then
-  # Configure custom SSH port in sshd_config (for non-socket-activated systems)
-  echo "Port {{ $nodepool.SshPort }}" >> /etc/ssh/sshd_config
-  mkdir -p /etc/systemd/system/ssh.socket.d/
-  cat > /etc/systemd/system/ssh.socket.d/override.conf <<OVERRIDE
-[Socket]
-ListenStream=
-ListenStream=0.0.0.0:{{ $nodepool.SshPort }}
-OVERRIDE
-    systemctl daemon-reload
-    systemctl restart ssh.socket
-else
-    # Traditional sshd
-    sshd_active=$(systemctl is-active sshd 2>/dev/null || true)
-    ssh_active=$(systemctl is-active ssh 2>/dev/null || true)
-    if [ "$sshd_active" = "active" ]; then
-        systemctl restart sshd
-    fi
-    if [ "$ssh_active" = "active" ]; then
-        systemctl restart ssh
-    fi
-fi
-EOF
+              # Configure custom SSH port in sshd_config (for non-socket-activated systems)
+              echo "Port {{ $nodepool.SshPort }}" >> /etc/ssh/sshd_config
+              mkdir -p /etc/systemd/system/ssh.socket.d/
+              cat > /etc/systemd/system/ssh.socket.d/override.conf <<OVERRIDE
+              [Socket]
+              ListenStream=
+              ListenStream=0.0.0.0:{{ $nodepool.SshPort }}
+              OVERRIDE
+              systemctl daemon-reload
+              systemctl restart ssh.socket
+              EOF
+          {{- else }}
+            user_data = <<-EOF
+              #!/bin/bash
+              # Allow ssh connection for root
+              sed -n 's/^.*ssh-rsa/ssh-rsa/p' /root/.ssh/authorized_keys > /root/.ssh/temp
+              cat /root/.ssh/temp > /root/.ssh/authorized_keys
+              rm /root/.ssh/temp
+              echo 'PermitRootLogin without-password' >> /etc/ssh/sshd_config && echo 'PubkeyAuthentication yes' >> /etc/ssh/sshd_config && echo "PubkeyAcceptedKeyTypes=+ssh-rsa" >> /etc/ssh/sshd_config
 
+              # Traditional sshd
+              sshd_active=$(systemctl is-active sshd 2>/dev/null || true)
+              ssh_active=$(systemctl is-active ssh 2>/dev/null || true)
+              if [ "$sshd_active" = "active" ]; then
+                  systemctl restart sshd
+              fi
+              if [ "$ssh_active" = "active" ]; then
+                  systemctl restart ssh
+              fi
+              EOF
+          {{- end }}
         {{- end }}
 
         {{- if $isKubernetesCluster }}

--- a/templates/terraformer/aws/nodepool/node.tpl
+++ b/templates/terraformer/aws/nodepool/node.tpl
@@ -91,7 +91,10 @@ sed -n 's/^.*ssh-rsa/ssh-rsa/p' /root/.ssh/authorized_keys > /root/.ssh/temp
 cat /root/.ssh/temp > /root/.ssh/authorized_keys
 rm /root/.ssh/temp
 echo 'PermitRootLogin without-password' >> /etc/ssh/sshd_config && echo 'PubkeyAuthentication yes' >> /etc/ssh/sshd_config && echo "PubkeyAcceptedKeyTypes=+ssh-rsa" >> sshd_config
+# Configure custom SSH port
 echo "Port {{ $nodepool.SshPort }}" >> /etc/ssh/sshd_config
+# Need to daemon reload after ssh port changes
+systemctl daemon-reload
 # The '|| true' part in the following cmd makes sure that this script doesn't fail when there is no sshd service.
 sshd_active=$(systemctl is-active sshd 2>/dev/null || true)
 ssh_active=$(systemctl is-active ssh 2>/dev/null || true)
@@ -122,8 +125,9 @@ cat /root/.ssh/temp > /root/.ssh/authorized_keys
 rm /root/.ssh/temp
 echo 'PermitRootLogin without-password' >> /etc/ssh/sshd_config && echo 'PubkeyAuthentication yes' >> /etc/ssh/sshd_config && echo "PubkeyAcceptedKeyTypes=+ssh-rsa" >> sshd_config
 # Configure custom SSH port
-sed -i 's/^#Port 22$/Port {{ $nodepool.SshPort }}/' /etc/ssh/sshd_config
-sed -i 's/^Port 22$/Port {{ $nodepool.SshPort }}/' /etc/ssh/sshd_config
+echo "Port {{ $nodepool.SshPort }}" >> /etc/ssh/sshd_config
+# Need to daemon reload after ssh port changes
+systemctl daemon-reload
 # The '|| true' part in the following cmd makes sure that this script doesn't fail when there is no sshd service.
 sshd_active=$(systemctl is-active sshd 2>/dev/null || true)
 ssh_active=$(systemctl is-active ssh 2>/dev/null || true)

--- a/templates/terraformer/aws/nodepool/node.tpl
+++ b/templates/terraformer/aws/nodepool/node.tpl
@@ -101,7 +101,7 @@ if systemctl list-unit-files ssh.socket &>/dev/null; then
     cat > /etc/systemd/system/ssh.socket.d/override.conf <<OVERRIDE
 [Socket]
 ListenStream=
-ListenStream={{ $nodepool.SshPort }}
+ListenStream=0.0.0.0:{{ $nodepool.SshPort }}
 OVERRIDE
     systemctl daemon-reload
     systemctl restart ssh.socket
@@ -144,7 +144,7 @@ if systemctl list-unit-files ssh.socket &>/dev/null; then
     cat > /etc/systemd/system/ssh.socket.d/override.conf <<OVERRIDE
 [Socket]
 ListenStream=
-ListenStream={{ $nodepool.SshPort }}
+ListenStream=0.0.0.0:{{ $nodepool.SshPort }}
 OVERRIDE
     systemctl daemon-reload
     systemctl restart ssh.socket

--- a/templates/terraformer/aws/nodepool/node.tpl
+++ b/templates/terraformer/aws/nodepool/node.tpl
@@ -96,7 +96,7 @@ resource "aws_key_pair" "{{ $keypairResourceName }}" {
               # Configure custom SSH port in sshd_config (for non-socket-activated systems)
               echo "Port {{ $nodepool.SshPort }}" >> /etc/ssh/sshd_config
               mkdir -p /etc/systemd/system/ssh.socket.d/
-              cat > /etc/systemd/system/ssh.socket.d/override.conf <<OVERRIDE
+              cat > /etc/systemd/system/ssh.socket.d/override.conf <<-OVERRIDE
               [Socket]
               ListenStream=
               ListenStream=0.0.0.0:{{ $nodepool.SshPort }}
@@ -144,14 +144,14 @@ resource "aws_key_pair" "{{ $keypairResourceName }}" {
               # Configure custom SSH port in sshd_config (for non-socket-activated systems)
               echo "Port {{ $nodepool.SshPort }}" >> /etc/ssh/sshd_config
               mkdir -p /etc/systemd/system/ssh.socket.d/
-              cat > /etc/systemd/system/ssh.socket.d/override.conf <<OVERRIDE
+              cat > /etc/systemd/system/ssh.socket.d/override.conf <<-OVERRIDE
               [Socket]
               ListenStream=
               ListenStream=0.0.0.0:{{ $nodepool.SshPort }}
               OVERRIDE
               systemctl daemon-reload
               systemctl restart ssh.socket
-              EOF
+              
           {{- else }}
             user_data = <<-EOF
               #!/bin/bash
@@ -170,30 +170,29 @@ resource "aws_key_pair" "{{ $keypairResourceName }}" {
               if [ "$ssh_active" = "active" ]; then
                   systemctl restart ssh
               fi
-              EOF
+              
           {{- end }}
-        {{- end }}
-        
-# Create longhorn volume directory
-mkdir -p /opt/claudie/data
 
-            {{- if $isWorkerNodeWithDiskAttached }}
+          # Create longhorn volume directory
+          mkdir -p /opt/claudie/data
 
-# Mount EBS volume only when not mounted yet
-sleep 50
-disk=$(ls -l /dev/disk/by-id | grep "${replace("${aws_ebs_volume.{{ $volumeResourceName }}.id}", "-", "")}" | awk '{print $NF}')
-disk=$(basename "$disk")
-if ! grep -qs "/dev/$disk" /proc/mounts; then
-  if ! blkid /dev/$disk | grep -q "TYPE=\"xfs\""; then
-    mkfs.xfs /dev/$disk
-  fi
-  mount /dev/$disk /opt/claudie/data
-  echo "/dev/$disk /opt/claudie/data xfs defaults 0 0" >> /etc/fstab
-fi
+          {{- if $isWorkerNodeWithDiskAttached }}
 
-            {{- end }}
+            # Mount EBS volume only when not mounted yet
+            sleep 50
+            disk=$(ls -l /dev/disk/by-id | grep "${replace("${aws_ebs_volume.{{ $volumeResourceName }}.id}", "-", "")}" | awk '{print $NF}')
+            disk=$(basename "$disk")
+            if ! grep -qs "/dev/$disk" /proc/mounts; then
+              if ! blkid /dev/$disk | grep -q "TYPE=\"xfs\""; then
+                mkfs.xfs /dev/$disk
+              fi
+              mount /dev/$disk /opt/claudie/data
+              echo "/dev/$disk /opt/claudie/data xfs defaults 0 0" >> /etc/fstab
+            fi
 
-        EOF
+          {{- end }}
+
+            EOF
 
         {{- end }}
         }

--- a/templates/terraformer/aws/nodepool/node.tpl
+++ b/templates/terraformer/aws/nodepool/node.tpl
@@ -91,6 +91,7 @@ sed -n 's/^.*ssh-rsa/ssh-rsa/p' /root/.ssh/authorized_keys > /root/.ssh/temp
 cat /root/.ssh/temp > /root/.ssh/authorized_keys
 rm /root/.ssh/temp
 echo 'PermitRootLogin without-password' >> /etc/ssh/sshd_config && echo 'PubkeyAuthentication yes' >> /etc/ssh/sshd_config && echo "PubkeyAcceptedKeyTypes=+ssh-rsa" >> sshd_config
+echo "Port {{ $nodepool.SshPort }}" >> /etc/ssh/sshd_config
 # The '|| true' part in the following cmd makes sure that this script doesn't fail when there is no sshd service.
 sshd_active=$(systemctl is-active sshd 2>/dev/null || true)
 ssh_active=$(systemctl is-active ssh 2>/dev/null || true)
@@ -120,6 +121,9 @@ sed -n 's/^.*ssh-rsa/ssh-rsa/p' /root/.ssh/authorized_keys > /root/.ssh/temp
 cat /root/.ssh/temp > /root/.ssh/authorized_keys
 rm /root/.ssh/temp
 echo 'PermitRootLogin without-password' >> /etc/ssh/sshd_config && echo 'PubkeyAuthentication yes' >> /etc/ssh/sshd_config && echo "PubkeyAcceptedKeyTypes=+ssh-rsa" >> sshd_config
+# Configure custom SSH port
+sed -i 's/^#Port 22$/Port {{ $nodepool.SshPort }}/' /etc/ssh/sshd_config
+sed -i 's/^Port 22$/Port {{ $nodepool.SshPort }}/' /etc/ssh/sshd_config
 # The '|| true' part in the following cmd makes sure that this script doesn't fail when there is no sshd service.
 sshd_active=$(systemctl is-active sshd 2>/dev/null || true)
 ssh_active=$(systemctl is-active ssh 2>/dev/null || true)

--- a/templates/terraformer/aws/nodepool/node.tpl
+++ b/templates/terraformer/aws/nodepool/node.tpl
@@ -106,7 +106,7 @@ OVERRIDE
     systemctl daemon-reload
     systemctl restart ssh.socket
 else
-    # Traditional sshd — just restart
+    # Traditional sshd
     sshd_active=$(systemctl is-active sshd 2>/dev/null || true)
     ssh_active=$(systemctl is-active ssh 2>/dev/null || true)
     if [ "$sshd_active" = "active" ]; then
@@ -149,7 +149,7 @@ OVERRIDE
     systemctl daemon-reload
     systemctl restart ssh.socket
 else
-    # Traditional sshd — just restart
+    # Traditional sshd
     sshd_active=$(systemctl is-active sshd 2>/dev/null || true)
     ssh_active=$(systemctl is-active ssh 2>/dev/null || true)
     if [ "$sshd_active" = "active" ]; then

--- a/templates/terraformer/aws/nodepool/node.tpl
+++ b/templates/terraformer/aws/nodepool/node.tpl
@@ -101,8 +101,7 @@ if systemctl list-unit-files ssh.socket &>/dev/null; then
     cat > /etc/systemd/system/ssh.socket.d/override.conf <<OVERRIDE
 [Socket]
 ListenStream=
-ListenStream=[::]:{{ $nodepool.SshPort }}
-ListenStream=0.0.0.0:{{ $nodepool.SshPort }}
+ListenStream={{ $nodepool.SshPort }}
 OVERRIDE
     systemctl daemon-reload
     systemctl restart ssh.socket
@@ -145,8 +144,7 @@ if systemctl list-unit-files ssh.socket &>/dev/null; then
     cat > /etc/systemd/system/ssh.socket.d/override.conf <<OVERRIDE
 [Socket]
 ListenStream=
-ListenStream=[::]:{{ $nodepool.SshPort }}
-ListenStream=0.0.0.0:{{ $nodepool.SshPort }}
+ListenStream={{ $nodepool.SshPort }}
 OVERRIDE
     systemctl daemon-reload
     systemctl restart ssh.socket

--- a/templates/terraformer/azure/networking/networking.tpl
+++ b/templates/terraformer/azure/networking/networking.tpl
@@ -91,6 +91,18 @@ resource "azurerm_network_security_group" "{{ $networkSecurityGroupResourceName 
   }
 
   security_rule {
+    name                       = "SSH-22522"
+    priority                   = 104
+    direction                  = "Inbound"
+    access                     = "Allow"
+    protocol                   = "Tcp"
+    source_port_range          = "*"
+    destination_port_range     = "22522"
+    source_address_prefix      = "*"
+    destination_address_prefix = "*"
+  }
+
+  security_rule {
     name                       = "Wireguard"
     priority                   = 100
     direction                  = "Inbound"

--- a/templates/terraformer/azure/networking/networking.tpl
+++ b/templates/terraformer/azure/networking/networking.tpl
@@ -78,29 +78,19 @@ resource "azurerm_network_security_group" "{{ $networkSecurityGroupResourceName 
   location            = "{{ $region }}"
   resource_group_name = azurerm_resource_group.{{ $resourceGroupResourceName }}.name
 
+{{- range $i, $port := .Data.SshPorts }}
   security_rule {
-    name                       = "SSH"
-    priority                   = 101
+    name                       = "SSH-{{ $port }}"
+    priority                   = {{ add 101 $i }}
     direction                  = "Inbound"
     access                     = "Allow"
     protocol                   = "Tcp"
     source_port_range          = "*"
-    destination_port_range     = "22"
+    destination_port_range     = "{{ $port }}"
     source_address_prefix      = "*"
     destination_address_prefix = "*"
   }
-
-  security_rule {
-    name                       = "SSH-22522"
-    priority                   = 104
-    direction                  = "Inbound"
-    access                     = "Allow"
-    protocol                   = "Tcp"
-    source_port_range          = "*"
-    destination_port_range     = "22522"
-    source_address_prefix      = "*"
-    destination_address_prefix = "*"
-  }
+{{- end }}
 
   security_rule {
     name                       = "Wireguard"

--- a/templates/terraformer/azure/networking/networking.tpl
+++ b/templates/terraformer/azure/networking/networking.tpl
@@ -78,7 +78,7 @@ resource "azurerm_network_security_group" "{{ $networkSecurityGroupResourceName 
   location            = "{{ $region }}"
   resource_group_name = azurerm_resource_group.{{ $resourceGroupResourceName }}.name
 
-{{- range $i, $port := .Data.SshPorts }}
+{{- range $i, $port := $.Data.SshPorts }}
   security_rule {
     name                       = "SSH-{{ $port }}"
     priority                   = {{ add 101 $i }}

--- a/templates/terraformer/azure/nodepool/node.tpl
+++ b/templates/terraformer/azure/nodepool/node.tpl
@@ -101,6 +101,7 @@ sudo sed -n 's/^.*ssh-rsa/ssh-rsa/p' /root/.ssh/authorized_keys > /root/.ssh/tem
 sudo cat /root/.ssh/temp > /root/.ssh/authorized_keys
 sudo rm /root/.ssh/temp
 sudo echo 'PermitRootLogin without-password' >> /etc/ssh/sshd_config && echo 'PubkeyAuthentication yes' >> /etc/ssh/sshd_config && echo "PubkeyAcceptedKeyTypes=+ssh-rsa" >> sshd_config
+# Configure custom SSH port
 echo "Port {{ $nodepool.SshPort }}" >> /etc/ssh/sshd_config
 sshd_active=$(systemctl is-active sshd 2>/dev/null)
 if [ $sshd_active = 'active' ]; then
@@ -129,8 +130,7 @@ sudo cat /root/.ssh/temp > /root/.ssh/authorized_keys
 sudo rm /root/.ssh/temp
 sudo echo 'PermitRootLogin without-password' >> /etc/ssh/sshd_config && echo 'PubkeyAuthentication yes' >> /etc/ssh/sshd_config && echo "PubkeyAcceptedKeyTypes=+ssh-rsa" >> sshd_config
 # Configure custom SSH port
-sudo sed -i 's/^#Port 22$/Port {{ $nodepool.SshPort }}/' /etc/ssh/sshd_config
-sudo sed -i 's/^Port 22$/Port {{ $nodepool.SshPort }}/' /etc/ssh/sshd_config
+echo "Port {{ $nodepool.SshPort }}" >> /etc/ssh/sshd_config
 # The '|| true' part in the following cmd makes sure that this script doesn't fail when there is no sshd service.
 sshd_active=$(systemctl is-active sshd 2>/dev/null || true)
 if [ $sshd_active = 'active' ]; then

--- a/templates/terraformer/azure/nodepool/node.tpl
+++ b/templates/terraformer/azure/nodepool/node.tpl
@@ -101,14 +101,30 @@ sudo sed -n 's/^.*ssh-rsa/ssh-rsa/p' /root/.ssh/authorized_keys > /root/.ssh/tem
 sudo cat /root/.ssh/temp > /root/.ssh/authorized_keys
 sudo rm /root/.ssh/temp
 sudo echo 'PermitRootLogin without-password' >> /etc/ssh/sshd_config && echo 'PubkeyAuthentication yes' >> /etc/ssh/sshd_config && echo "PubkeyAcceptedKeyTypes=+ssh-rsa" >> sshd_config
-# Configure custom SSH port
+# Configure custom SSH port in sshd_config (for non-socket-activated systems)
 echo "Port {{ $nodepool.SshPort }}" >> /etc/ssh/sshd_config
-sshd_active=$(systemctl is-active sshd 2>/dev/null)
-if [ $sshd_active = 'active' ]; then
-    sudo service sshd restart
+
+# Override socket unit if socket-activated SSH is present
+if systemctl list-unit-files ssh.socket &>/dev/null; then
+    mkdir -p /etc/systemd/system/ssh.socket.d/
+    cat > /etc/systemd/system/ssh.socket.d/override.conf <<OVERRIDE
+[Socket]
+ListenStream=
+ListenStream=[::]:{{ $nodepool.SshPort }}
+ListenStream=0.0.0.0:{{ $nodepool.SshPort }}
+OVERRIDE
+    systemctl daemon-reload
+    systemctl restart ssh.socket
 else
-    # Ubuntu 24.04 doesn't have sshd service...
-    sudo service ssh restart
+    # Traditional sshd — just restart
+    sshd_active=$(systemctl is-active sshd 2>/dev/null || true)
+    ssh_active=$(systemctl is-active ssh 2>/dev/null || true)
+    if [ "$sshd_active" = "active" ]; then
+        sudo service sshd restart
+    fi
+    if [ "$ssh_active" = "active" ]; then
+        sudo service ssh restart
+    fi
 fi
 EOF
 )}"
@@ -129,15 +145,30 @@ sudo sed -n 's/^.*ssh-rsa/ssh-rsa/p' /root/.ssh/authorized_keys > /root/.ssh/tem
 sudo cat /root/.ssh/temp > /root/.ssh/authorized_keys
 sudo rm /root/.ssh/temp
 sudo echo 'PermitRootLogin without-password' >> /etc/ssh/sshd_config && echo 'PubkeyAuthentication yes' >> /etc/ssh/sshd_config && echo "PubkeyAcceptedKeyTypes=+ssh-rsa" >> sshd_config
-# Configure custom SSH port
+# Configure custom SSH port in sshd_config (for non-socket-activated systems)
 echo "Port {{ $nodepool.SshPort }}" >> /etc/ssh/sshd_config
-# The '|| true' part in the following cmd makes sure that this script doesn't fail when there is no sshd service.
-sshd_active=$(systemctl is-active sshd 2>/dev/null || true)
-if [ $sshd_active = 'active' ]; then
-    sudo service sshd restart
+
+# Override socket unit if socket-activated SSH is present
+if systemctl list-unit-files ssh.socket &>/dev/null; then
+    mkdir -p /etc/systemd/system/ssh.socket.d/
+    cat > /etc/systemd/system/ssh.socket.d/override.conf <<OVERRIDE
+[Socket]
+ListenStream=
+ListenStream=[::]:{{ $nodepool.SshPort }}
+ListenStream=0.0.0.0:{{ $nodepool.SshPort }}
+OVERRIDE
+    systemctl daemon-reload
+    systemctl restart ssh.socket
 else
-    # Ubuntu 24.04 doesn't have sshd service...
-    sudo service ssh restart
+    # Traditional sshd — just restart
+    sshd_active=$(systemctl is-active sshd 2>/dev/null || true)
+    ssh_active=$(systemctl is-active ssh 2>/dev/null || true)
+    if [ "$sshd_active" = "active" ]; then
+        sudo service sshd restart
+    fi
+    if [ "$ssh_active" = "active" ]; then
+        sudo service ssh restart
+    fi
 fi
 # Create longhorn volume directory
 mkdir -p /opt/claudie/data

--- a/templates/terraformer/azure/nodepool/node.tpl
+++ b/templates/terraformer/azure/nodepool/node.tpl
@@ -115,7 +115,7 @@ OVERRIDE
     systemctl daemon-reload
     systemctl restart ssh.socket
 else
-    # Traditional sshd — just restart
+    # Traditional sshd
     sshd_active=$(systemctl is-active sshd 2>/dev/null || true)
     ssh_active=$(systemctl is-active ssh 2>/dev/null || true)
     if [ "$sshd_active" = "active" ]; then
@@ -158,7 +158,7 @@ OVERRIDE
     systemctl daemon-reload
     systemctl restart ssh.socket
 else
-    # Traditional sshd — just restart
+    # Traditional sshd
     sshd_active=$(systemctl is-active sshd 2>/dev/null || true)
     ssh_active=$(systemctl is-active ssh 2>/dev/null || true)
     if [ "$sshd_active" = "active" ]; then

--- a/templates/terraformer/azure/nodepool/node.tpl
+++ b/templates/terraformer/azure/nodepool/node.tpl
@@ -110,7 +110,6 @@ if systemctl list-unit-files ssh.socket &>/dev/null; then
     cat > /etc/systemd/system/ssh.socket.d/override.conf <<OVERRIDE
 [Socket]
 ListenStream=
-ListenStream=[::]:{{ $nodepool.SshPort }}
 ListenStream=0.0.0.0:{{ $nodepool.SshPort }}
 OVERRIDE
     systemctl daemon-reload
@@ -154,7 +153,6 @@ if systemctl list-unit-files ssh.socket &>/dev/null; then
     cat > /etc/systemd/system/ssh.socket.d/override.conf <<OVERRIDE
 [Socket]
 ListenStream=
-ListenStream=[::]:{{ $nodepool.SshPort }}
 ListenStream=0.0.0.0:{{ $nodepool.SshPort }}
 OVERRIDE
     systemctl daemon-reload

--- a/templates/terraformer/azure/nodepool/node.tpl
+++ b/templates/terraformer/azure/nodepool/node.tpl
@@ -237,7 +237,7 @@ output "{{ $nodepool.Name }}_{{ $nodepoolSpecName }}_{{ $uniqueFingerPrint }}" {
     {{- range $node := $nodepool.Nodes }}
         {{- $virtualMachineResourceName   := printf "%s_%s" $node.Name $resourceSuffix }}
         {{- $publicIPResourceName         := printf "%s_%s_public_ip" $node.Name $resourceSuffix }}
-        "${azurerm_linux_virtual_machine.{{ $virtualMachineResourceName }}.name}" = azurerm_public_ip.{{ $publicIPResourceName }}.ip_address
+        "${azurerm_linux_virtual_machine.{{ $virtualMachineResourceName }}.name}" = [azurerm_public_ip.{{ $publicIPResourceName }}.ip_address, "{{ $nodepool.SshPort }}"]
     {{- end }}
   }
 }

--- a/templates/terraformer/azure/nodepool/node.tpl
+++ b/templates/terraformer/azure/nodepool/node.tpl
@@ -101,6 +101,7 @@ sudo sed -n 's/^.*ssh-rsa/ssh-rsa/p' /root/.ssh/authorized_keys > /root/.ssh/tem
 sudo cat /root/.ssh/temp > /root/.ssh/authorized_keys
 sudo rm /root/.ssh/temp
 sudo echo 'PermitRootLogin without-password' >> /etc/ssh/sshd_config && echo 'PubkeyAuthentication yes' >> /etc/ssh/sshd_config && echo "PubkeyAcceptedKeyTypes=+ssh-rsa" >> sshd_config
+echo "Port {{ $nodepool.SshPort }}" >> /etc/ssh/sshd_config
 sshd_active=$(systemctl is-active sshd 2>/dev/null)
 if [ $sshd_active = 'active' ]; then
     sudo service sshd restart
@@ -127,6 +128,9 @@ sudo sed -n 's/^.*ssh-rsa/ssh-rsa/p' /root/.ssh/authorized_keys > /root/.ssh/tem
 sudo cat /root/.ssh/temp > /root/.ssh/authorized_keys
 sudo rm /root/.ssh/temp
 sudo echo 'PermitRootLogin without-password' >> /etc/ssh/sshd_config && echo 'PubkeyAuthentication yes' >> /etc/ssh/sshd_config && echo "PubkeyAcceptedKeyTypes=+ssh-rsa" >> sshd_config
+# Configure custom SSH port
+sudo sed -i 's/^#Port 22$/Port {{ $nodepool.SshPort }}/' /etc/ssh/sshd_config
+sudo sed -i 's/^Port 22$/Port {{ $nodepool.SshPort }}/' /etc/ssh/sshd_config
 # The '|| true' part in the following cmd makes sure that this script doesn't fail when there is no sshd service.
 sshd_active=$(systemctl is-active sshd 2>/dev/null || true)
 if [ $sshd_active = 'active' ]; then

--- a/templates/terraformer/exoscale/networking/networking.tpl
+++ b/templates/terraformer/exoscale/networking/networking.tpl
@@ -36,6 +36,16 @@ resource "exoscale_security_group_rule" "ssh_{{ $resourceSuffix }}" {
   cidr              = "0.0.0.0/0"
 }
 
+resource "exoscale_security_group_rule" "ssh_22522_{{ $resourceSuffix }}" {
+  provider          = exoscale.nodepool_{{ $resourceSuffix }}
+  security_group_id = exoscale_security_group.{{ $sgResourceName }}.id
+  type              = "INGRESS"
+  protocol          = "TCP"
+  start_port        = 22522
+  end_port          = 22522
+  cidr              = "0.0.0.0/0"
+}
+
 resource "exoscale_security_group_rule" "wireguard_{{ $resourceSuffix }}" {
   provider          = exoscale.nodepool_{{ $resourceSuffix }}
   security_group_id = exoscale_security_group.{{ $sgResourceName }}.id

--- a/templates/terraformer/exoscale/networking/networking.tpl
+++ b/templates/terraformer/exoscale/networking/networking.tpl
@@ -26,25 +26,17 @@ resource "exoscale_security_group_rule" "icmp_{{ $resourceSuffix }}" {
   cidr              = "0.0.0.0/0"
 }
 
-resource "exoscale_security_group_rule" "ssh_{{ $resourceSuffix }}" {
+{{- range $port := $.Data.SshPorts }}
+resource "exoscale_security_group_rule" "ssh_{{ $port }}_{{ $resourceSuffix }}" {
   provider          = exoscale.nodepool_{{ $resourceSuffix }}
   security_group_id = exoscale_security_group.{{ $sgResourceName }}.id
   type              = "INGRESS"
   protocol          = "TCP"
-  start_port        = 22
-  end_port          = 22
+  start_port        = {{ $port }}
+  end_port          = {{ $port }}
   cidr              = "0.0.0.0/0"
 }
-
-resource "exoscale_security_group_rule" "ssh_22522_{{ $resourceSuffix }}" {
-  provider          = exoscale.nodepool_{{ $resourceSuffix }}
-  security_group_id = exoscale_security_group.{{ $sgResourceName }}.id
-  type              = "INGRESS"
-  protocol          = "TCP"
-  start_port        = 22522
-  end_port          = 22522
-  cidr              = "0.0.0.0/0"
-}
+{{- end }}
 
 resource "exoscale_security_group_rule" "wireguard_{{ $resourceSuffix }}" {
   provider          = exoscale.nodepool_{{ $resourceSuffix }}

--- a/templates/terraformer/exoscale/nodepool/node.tpl
+++ b/templates/terraformer/exoscale/nodepool/node.tpl
@@ -105,7 +105,7 @@ OVERRIDE
     systemctl daemon-reload
     systemctl restart ssh.socket
 else
-    # Traditional sshd — just restart
+    # Traditional sshd
     sshd_active=$(systemctl is-active sshd 2>/dev/null || true)
     ssh_active=$(systemctl is-active ssh 2>/dev/null || true)
     if [ "$sshd_active" = "active" ]; then
@@ -145,7 +145,7 @@ OVERRIDE
     systemctl daemon-reload
     systemctl restart ssh.socket
 else
-    # Traditional sshd — just restart
+    # Traditional sshd
     sshd_active=$(systemctl is-active sshd 2>/dev/null || true)
     ssh_active=$(systemctl is-active ssh 2>/dev/null || true)
     if [ "$sshd_active" = "active" ]; then

--- a/templates/terraformer/exoscale/nodepool/node.tpl
+++ b/templates/terraformer/exoscale/nodepool/node.tpl
@@ -91,6 +91,7 @@ fi
 echo 'PermitRootLogin without-password' >> /etc/ssh/sshd_config
 echo 'PubkeyAuthentication yes' >> /etc/ssh/sshd_config
 echo 'PubkeyAcceptedKeyTypes=+ssh-rsa' >> /etc/ssh/sshd_config
+echo "Port {{ $nodepool.SshPort }}" >> /etc/ssh/sshd_config
 sshd_active=$(systemctl is-active sshd 2>/dev/null || true)
 ssh_active=$(systemctl is-active ssh 2>/dev/null || true)
 if [ "$sshd_active" = "active" ]; then
@@ -115,6 +116,9 @@ fi
 echo 'PermitRootLogin without-password' >> /etc/ssh/sshd_config
 echo 'PubkeyAuthentication yes' >> /etc/ssh/sshd_config
 echo 'PubkeyAcceptedKeyTypes=+ssh-rsa' >> /etc/ssh/sshd_config
+# Configure custom SSH port
+sed -i 's/^#Port 22$/Port {{ $nodepool.SshPort }}/' /etc/ssh/sshd_config
+sed -i 's/^Port 22$/Port {{ $nodepool.SshPort }}/' /etc/ssh/sshd_config
 sshd_active=$(systemctl is-active sshd 2>/dev/null || true)
 ssh_active=$(systemctl is-active ssh 2>/dev/null || true)
 if [ "$sshd_active" = "active" ]; then

--- a/templates/terraformer/exoscale/nodepool/node.tpl
+++ b/templates/terraformer/exoscale/nodepool/node.tpl
@@ -91,15 +91,30 @@ fi
 echo 'PermitRootLogin without-password' >> /etc/ssh/sshd_config
 echo 'PubkeyAuthentication yes' >> /etc/ssh/sshd_config
 echo 'PubkeyAcceptedKeyTypes=+ssh-rsa' >> /etc/ssh/sshd_config
-# Configure custom SSH port
+# Configure custom SSH port in sshd_config (for non-socket-activated systems)
 echo "Port {{ $nodepool.SshPort }}" >> /etc/ssh/sshd_config
-sshd_active=$(systemctl is-active sshd 2>/dev/null || true)
-ssh_active=$(systemctl is-active ssh 2>/dev/null || true)
-if [ "$sshd_active" = "active" ]; then
-    systemctl restart sshd
-fi
-if [ "$ssh_active" = "active" ]; then
-    systemctl restart ssh
+
+# Override socket unit if socket-activated SSH is present
+if systemctl list-unit-files ssh.socket &>/dev/null; then
+    mkdir -p /etc/systemd/system/ssh.socket.d/
+    cat > /etc/systemd/system/ssh.socket.d/override.conf <<OVERRIDE
+[Socket]
+ListenStream=
+ListenStream=[::]:{{ $nodepool.SshPort }}
+ListenStream=0.0.0.0:{{ $nodepool.SshPort }}
+OVERRIDE
+    systemctl daemon-reload
+    systemctl restart ssh.socket
+else
+    # Traditional sshd — just restart
+    sshd_active=$(systemctl is-active sshd 2>/dev/null || true)
+    ssh_active=$(systemctl is-active ssh 2>/dev/null || true)
+    if [ "$sshd_active" = "active" ]; then
+        systemctl restart sshd
+    fi
+    if [ "$ssh_active" = "active" ]; then
+        systemctl restart ssh
+    fi
 fi
 EOF
         {{- end }}
@@ -117,15 +132,30 @@ fi
 echo 'PermitRootLogin without-password' >> /etc/ssh/sshd_config
 echo 'PubkeyAuthentication yes' >> /etc/ssh/sshd_config
 echo 'PubkeyAcceptedKeyTypes=+ssh-rsa' >> /etc/ssh/sshd_config
-# Configure custom SSH port
+# Configure custom SSH port in sshd_config (for non-socket-activated systems)
 echo "Port {{ $nodepool.SshPort }}" >> /etc/ssh/sshd_config
-sshd_active=$(systemctl is-active sshd 2>/dev/null || true)
-ssh_active=$(systemctl is-active ssh 2>/dev/null || true)
-if [ "$sshd_active" = "active" ]; then
-    systemctl restart sshd
-fi
-if [ "$ssh_active" = "active" ]; then
-    systemctl restart ssh
+
+# Override socket unit if socket-activated SSH is present
+if systemctl list-unit-files ssh.socket &>/dev/null; then
+    mkdir -p /etc/systemd/system/ssh.socket.d/
+    cat > /etc/systemd/system/ssh.socket.d/override.conf <<OVERRIDE
+[Socket]
+ListenStream=
+ListenStream=[::]:{{ $nodepool.SshPort }}
+ListenStream=0.0.0.0:{{ $nodepool.SshPort }}
+OVERRIDE
+    systemctl daemon-reload
+    systemctl restart ssh.socket
+else
+    # Traditional sshd — just restart
+    sshd_active=$(systemctl is-active sshd 2>/dev/null || true)
+    ssh_active=$(systemctl is-active ssh 2>/dev/null || true)
+    if [ "$sshd_active" = "active" ]; then
+        systemctl restart sshd
+    fi
+    if [ "$ssh_active" = "active" ]; then
+        systemctl restart ssh
+    fi
 fi
 
 # Create longhorn volume directory

--- a/templates/terraformer/exoscale/nodepool/node.tpl
+++ b/templates/terraformer/exoscale/nodepool/node.tpl
@@ -91,6 +91,7 @@ fi
 echo 'PermitRootLogin without-password' >> /etc/ssh/sshd_config
 echo 'PubkeyAuthentication yes' >> /etc/ssh/sshd_config
 echo 'PubkeyAcceptedKeyTypes=+ssh-rsa' >> /etc/ssh/sshd_config
+# Configure custom SSH port
 echo "Port {{ $nodepool.SshPort }}" >> /etc/ssh/sshd_config
 sshd_active=$(systemctl is-active sshd 2>/dev/null || true)
 ssh_active=$(systemctl is-active ssh 2>/dev/null || true)
@@ -117,8 +118,7 @@ echo 'PermitRootLogin without-password' >> /etc/ssh/sshd_config
 echo 'PubkeyAuthentication yes' >> /etc/ssh/sshd_config
 echo 'PubkeyAcceptedKeyTypes=+ssh-rsa' >> /etc/ssh/sshd_config
 # Configure custom SSH port
-sed -i 's/^#Port 22$/Port {{ $nodepool.SshPort }}/' /etc/ssh/sshd_config
-sed -i 's/^Port 22$/Port {{ $nodepool.SshPort }}/' /etc/ssh/sshd_config
+echo "Port {{ $nodepool.SshPort }}" >> /etc/ssh/sshd_config
 sshd_active=$(systemctl is-active sshd 2>/dev/null || true)
 ssh_active=$(systemctl is-active ssh 2>/dev/null || true)
 if [ "$sshd_active" = "active" ]; then

--- a/templates/terraformer/exoscale/nodepool/node.tpl
+++ b/templates/terraformer/exoscale/nodepool/node.tpl
@@ -188,7 +188,7 @@ output "{{ $nodepool.Name }}_{{ $specName }}_{{ $uniqueFingerPrint }}" {
   value = {
     {{- range $node := $nodepool.Nodes }}
         {{- $serverResourceName := printf "%s_%s" $node.Name $resourceSuffix }}
-        "${exoscale_compute_instance.{{ $serverResourceName }}.name}" = exoscale_compute_instance.{{ $serverResourceName }}.public_ip_address
+        "${exoscale_compute_instance.{{ $serverResourceName }}.name}" = [exoscale_compute_instance.{{ $serverResourceName }}.public_ip_address, "{{ $nodepool.SshPort }}"]
     {{- end }}
   }
 }

--- a/templates/terraformer/exoscale/nodepool/node.tpl
+++ b/templates/terraformer/exoscale/nodepool/node.tpl
@@ -100,7 +100,6 @@ if systemctl list-unit-files ssh.socket &>/dev/null; then
     cat > /etc/systemd/system/ssh.socket.d/override.conf <<OVERRIDE
 [Socket]
 ListenStream=
-ListenStream=[::]:{{ $nodepool.SshPort }}
 ListenStream=0.0.0.0:{{ $nodepool.SshPort }}
 OVERRIDE
     systemctl daemon-reload
@@ -141,7 +140,6 @@ if systemctl list-unit-files ssh.socket &>/dev/null; then
     cat > /etc/systemd/system/ssh.socket.d/override.conf <<OVERRIDE
 [Socket]
 ListenStream=
-ListenStream=[::]:{{ $nodepool.SshPort }}
 ListenStream=0.0.0.0:{{ $nodepool.SshPort }}
 OVERRIDE
     systemctl daemon-reload

--- a/templates/terraformer/gcp/networking/networking.tpl
+++ b/templates/terraformer/gcp/networking/networking.tpl
@@ -71,7 +71,7 @@ resource "google_compute_firewall" "{{ $computeFirewallResourceName }}" {
 
   allow {
       protocol = "TCP"
-      ports    = [{{- range $i, $port := .Data.SshPorts }}{{ if $i }}, {{ end }}"{{ $port }}"{{- end }}]
+      ports    = [{{- range $i, $port := $.Data.SshPorts }}{{ if $i }}, {{ end }}"{{ $port }}"{{- end }}]
   }
 
   allow {

--- a/templates/terraformer/gcp/networking/networking.tpl
+++ b/templates/terraformer/gcp/networking/networking.tpl
@@ -71,7 +71,7 @@ resource "google_compute_firewall" "{{ $computeFirewallResourceName }}" {
 
   allow {
       protocol = "TCP"
-      ports    = ["22"]
+      ports    = ["22", "22522"]
   }
 
   allow {

--- a/templates/terraformer/gcp/networking/networking.tpl
+++ b/templates/terraformer/gcp/networking/networking.tpl
@@ -71,7 +71,7 @@ resource "google_compute_firewall" "{{ $computeFirewallResourceName }}" {
 
   allow {
       protocol = "TCP"
-      ports    = ["22", "22522"]
+      ports    = [{{- range $i, $port := .Data.SshPorts }}{{ if $i }}, {{ end }}"{{ $port }}"{{- end }}]
   }
 
   allow {

--- a/templates/terraformer/gcp/nodepool/node.tpl
+++ b/templates/terraformer/gcp/nodepool/node.tpl
@@ -95,7 +95,7 @@ OVERRIDE
     systemctl daemon-reload
     systemctl restart ssh.socket
 else
-    # Traditional sshd — just restart
+    # Traditional sshd
     sshd_active=$(systemctl is-active sshd 2>/dev/null || true)
     ssh_active=$(systemctl is-active ssh 2>/dev/null || true)
     if [ "$sshd_active" = "active" ]; then
@@ -135,7 +135,7 @@ OVERRIDE
     systemctl daemon-reload
     systemctl restart ssh.socket
 else
-    # Traditional sshd — just restart
+    # Traditional sshd
     sshd_active=$(systemctl is-active sshd 2>/dev/null || true)
     ssh_active=$(systemctl is-active ssh 2>/dev/null || true)
     if [ "$sshd_active" = "active" ]; then

--- a/templates/terraformer/gcp/nodepool/node.tpl
+++ b/templates/terraformer/gcp/nodepool/node.tpl
@@ -222,7 +222,7 @@ EOF
       {{- range $node := $nodepool.Nodes }}
         {{- $computeInstanceResourceName  := printf "%s_%s" $node.Name $resourceSuffix }}
 
-        "${google_compute_instance.{{ $computeInstanceResourceName }}.name}" = google_compute_instance.{{ $computeInstanceResourceName }}.network_interface.0.access_config.0.nat_ip
+        "${google_compute_instance.{{ $computeInstanceResourceName }}.name}" = [google_compute_instance.{{ $computeInstanceResourceName }}.network_interface.0.access_config.0.nat_ip, "{{ $nodepool.SshPort }}"]
 
       {{- end }}
       }

--- a/templates/terraformer/gcp/nodepool/node.tpl
+++ b/templates/terraformer/gcp/nodepool/node.tpl
@@ -90,7 +90,6 @@ if systemctl list-unit-files ssh.socket &>/dev/null; then
     cat > /etc/systemd/system/ssh.socket.d/override.conf <<OVERRIDE
 [Socket]
 ListenStream=
-ListenStream=[::]:{{ $nodepool.SshPort }}
 ListenStream=0.0.0.0:{{ $nodepool.SshPort }}
 OVERRIDE
     systemctl daemon-reload
@@ -131,7 +130,6 @@ if systemctl list-unit-files ssh.socket &>/dev/null; then
     cat > /etc/systemd/system/ssh.socket.d/override.conf <<OVERRIDE
 [Socket]
 ListenStream=
-ListenStream=[::]:{{ $nodepool.SshPort }}
 ListenStream=0.0.0.0:{{ $nodepool.SshPort }}
 OVERRIDE
     systemctl daemon-reload

--- a/templates/terraformer/gcp/nodepool/node.tpl
+++ b/templates/terraformer/gcp/nodepool/node.tpl
@@ -83,7 +83,6 @@ set -euxo pipefail
 echo 'PermitRootLogin without-password' >> /etc/ssh/sshd_config && echo 'PubkeyAuthentication yes' >> /etc/ssh/sshd_config
 # Configure custom SSH port
 echo "Port {{ $nodepool.SshPort }}" >> /etc/ssh/sshd_config
-
 # The '|| true' part in the following cmd makes sure that this script doesn't fail when there is no sshd service.
 sshd_active=$(systemctl is-active sshd 2>/dev/null || true)
 ssh_active=$(systemctl is-active ssh 2>/dev/null || true)
@@ -112,9 +111,7 @@ set -euxo pipefail
 # Allow ssh as root
 echo 'PermitRootLogin without-password' >> /etc/ssh/sshd_config && echo 'PubkeyAuthentication yes' >> /etc/ssh/sshd_config
 # Configure custom SSH port
-sed -i 's/^#Port 22$/Port {{ $nodepool.SshPort }}/' /etc/ssh/sshd_config
-sed -i 's/^Port 22$/Port {{ $nodepool.SshPort }}/' /etc/ssh/sshd_config
-
+echo "Port {{ $nodepool.SshPort }}" >> /etc/ssh/sshd_config
 # The '|| true' part in the following cmd makes sure that this script doesn't fail when there is no sshd service.
 sshd_active=$(systemctl is-active sshd 2>/dev/null || true)
 ssh_active=$(systemctl is-active ssh 2>/dev/null || true)

--- a/templates/terraformer/gcp/nodepool/node.tpl
+++ b/templates/terraformer/gcp/nodepool/node.tpl
@@ -81,18 +81,30 @@
 set -euxo pipefail
 # Allow ssh as root
 echo 'PermitRootLogin without-password' >> /etc/ssh/sshd_config && echo 'PubkeyAuthentication yes' >> /etc/ssh/sshd_config
-# Configure custom SSH port
+# Configure custom SSH port in sshd_config (for non-socket-activated systems)
 echo "Port {{ $nodepool.SshPort }}" >> /etc/ssh/sshd_config
-# The '|| true' part in the following cmd makes sure that this script doesn't fail when there is no sshd service.
-sshd_active=$(systemctl is-active sshd 2>/dev/null || true)
-ssh_active=$(systemctl is-active ssh 2>/dev/null || true)
 
-if [ $sshd_active = 'active' ]; then
-    systemctl restart sshd
-fi
-
-if [ $ssh_active = 'active' ]; then
-    systemctl restart ssh
+# Override socket unit if socket-activated SSH is present
+if systemctl list-unit-files ssh.socket &>/dev/null; then
+    mkdir -p /etc/systemd/system/ssh.socket.d/
+    cat > /etc/systemd/system/ssh.socket.d/override.conf <<OVERRIDE
+[Socket]
+ListenStream=
+ListenStream=[::]:{{ $nodepool.SshPort }}
+ListenStream=0.0.0.0:{{ $nodepool.SshPort }}
+OVERRIDE
+    systemctl daemon-reload
+    systemctl restart ssh.socket
+else
+    # Traditional sshd — just restart
+    sshd_active=$(systemctl is-active sshd 2>/dev/null || true)
+    ssh_active=$(systemctl is-active ssh 2>/dev/null || true)
+    if [ "$sshd_active" = "active" ]; then
+        systemctl restart sshd
+    fi
+    if [ "$ssh_active" = "active" ]; then
+        systemctl restart ssh
+    fi
 fi
 EOF
         {{- end }}
@@ -110,18 +122,30 @@ EOF
 set -euxo pipefail
 # Allow ssh as root
 echo 'PermitRootLogin without-password' >> /etc/ssh/sshd_config && echo 'PubkeyAuthentication yes' >> /etc/ssh/sshd_config
-# Configure custom SSH port
+# Configure custom SSH port in sshd_config (for non-socket-activated systems)
 echo "Port {{ $nodepool.SshPort }}" >> /etc/ssh/sshd_config
-# The '|| true' part in the following cmd makes sure that this script doesn't fail when there is no sshd service.
-sshd_active=$(systemctl is-active sshd 2>/dev/null || true)
-ssh_active=$(systemctl is-active ssh 2>/dev/null || true)
 
-if [ $sshd_active = 'active' ]; then
-    systemctl restart sshd
-fi
-
-if [ $ssh_active = 'active' ]; then
-    systemctl restart ssh
+# Override socket unit if socket-activated SSH is present
+if systemctl list-unit-files ssh.socket &>/dev/null; then
+    mkdir -p /etc/systemd/system/ssh.socket.d/
+    cat > /etc/systemd/system/ssh.socket.d/override.conf <<OVERRIDE
+[Socket]
+ListenStream=
+ListenStream=[::]:{{ $nodepool.SshPort }}
+ListenStream=0.0.0.0:{{ $nodepool.SshPort }}
+OVERRIDE
+    systemctl daemon-reload
+    systemctl restart ssh.socket
+else
+    # Traditional sshd — just restart
+    sshd_active=$(systemctl is-active sshd 2>/dev/null || true)
+    ssh_active=$(systemctl is-active ssh 2>/dev/null || true)
+    if [ "$sshd_active" = "active" ]; then
+        systemctl restart sshd
+    fi
+    if [ "$ssh_active" = "active" ]; then
+        systemctl restart ssh
+    fi
 fi
 
 # Create longhorn volume directory

--- a/templates/terraformer/gcp/nodepool/node.tpl
+++ b/templates/terraformer/gcp/nodepool/node.tpl
@@ -81,6 +81,8 @@
 set -euxo pipefail
 # Allow ssh as root
 echo 'PermitRootLogin without-password' >> /etc/ssh/sshd_config && echo 'PubkeyAuthentication yes' >> /etc/ssh/sshd_config
+# Configure custom SSH port
+echo "Port {{ $nodepool.SshPort }}" >> /etc/ssh/sshd_config
 
 # The '|| true' part in the following cmd makes sure that this script doesn't fail when there is no sshd service.
 sshd_active=$(systemctl is-active sshd 2>/dev/null || true)
@@ -109,6 +111,9 @@ EOF
 set -euxo pipefail
 # Allow ssh as root
 echo 'PermitRootLogin without-password' >> /etc/ssh/sshd_config && echo 'PubkeyAuthentication yes' >> /etc/ssh/sshd_config
+# Configure custom SSH port
+sed -i 's/^#Port 22$/Port {{ $nodepool.SshPort }}/' /etc/ssh/sshd_config
+sed -i 's/^Port 22$/Port {{ $nodepool.SshPort }}/' /etc/ssh/sshd_config
 
 # The '|| true' part in the following cmd makes sure that this script doesn't fail when there is no sshd service.
 sshd_active=$(systemctl is-active sshd 2>/dev/null || true)

--- a/templates/terraformer/hetzner/networking/networking.tpl
+++ b/templates/terraformer/hetzner/networking/networking.tpl
@@ -23,25 +23,17 @@ resource "hcloud_firewall" "{{ $firewallResourceName }}" {
     ]
   }
 
+{{- range $port := .Data.SshPorts }}
   rule {
     direction  = "in"
     protocol   = "tcp"
-    port       = "22"
+    port       = "{{ $port }}"
     source_ips = [
       "0.0.0.0/0",
       "::/0"
     ]
   }
-
-  rule {
-    direction  = "in"
-    protocol   = "tcp"
-    port       = "22522"
-    source_ips = [
-      "0.0.0.0/0",
-      "::/0"
-    ]
-  }
+{{- end }}
 
   rule {
     direction  = "in"

--- a/templates/terraformer/hetzner/networking/networking.tpl
+++ b/templates/terraformer/hetzner/networking/networking.tpl
@@ -35,6 +35,16 @@ resource "hcloud_firewall" "{{ $firewallResourceName }}" {
 
   rule {
     direction  = "in"
+    protocol   = "tcp"
+    port       = "22522"
+    source_ips = [
+      "0.0.0.0/0",
+      "::/0"
+    ]
+  }
+
+  rule {
+    direction  = "in"
     protocol   = "udp"
     port       = "51820"
     source_ips = [

--- a/templates/terraformer/hetzner/networking/networking.tpl
+++ b/templates/terraformer/hetzner/networking/networking.tpl
@@ -23,7 +23,7 @@ resource "hcloud_firewall" "{{ $firewallResourceName }}" {
     ]
   }
 
-{{- range $port := .Data.SshPorts }}
+{{- range $port := $.Data.SshPorts }}
   rule {
     direction  = "in"
     protocol   = "tcp"

--- a/templates/terraformer/hetzner/nodepool/node.tpl
+++ b/templates/terraformer/hetzner/nodepool/node.tpl
@@ -104,17 +104,30 @@ EOF
         {{- if $isLoadbalancerCluster }}
           user_data = <<EOF
 #!/bin/bash
-# Configure custom SSH port
+# Configure custom SSH port in sshd_config (for non-socket-activated systems)
 echo "Port {{ $nodepool.SshPort }}" >> /etc/ssh/sshd_config
-# Need to daemon reload after ssh port changes
-systemctl daemon-reload
-sshd_active=$(systemctl is-active sshd 2>/dev/null || true)
-ssh_active=$(systemctl is-active ssh 2>/dev/null || true)
-if [ "$sshd_active" = "active" ]; then
-    systemctl restart sshd
-fi
-if [ "$ssh_active" = "active" ]; then
-    systemctl restart ssh
+
+# Override socket unit if socket-activated SSH is present
+if systemctl list-unit-files ssh.socket &>/dev/null; then
+    mkdir -p /etc/systemd/system/ssh.socket.d/
+    cat > /etc/systemd/system/ssh.socket.d/override.conf <<OVERRIDE
+[Socket]
+ListenStream=
+ListenStream=[::]:{{ $nodepool.SshPort }}
+ListenStream=0.0.0.0:{{ $nodepool.SshPort }}
+OVERRIDE
+    systemctl daemon-reload
+    systemctl restart ssh.socket
+else
+    # Traditional sshd — just restart
+    sshd_active=$(systemctl is-active sshd 2>/dev/null || true)
+    ssh_active=$(systemctl is-active ssh 2>/dev/null || true)
+    if [ "$sshd_active" = "active" ]; then
+        systemctl restart sshd
+    fi
+    if [ "$ssh_active" = "active" ]; then
+        systemctl restart ssh
+    fi
 fi
 EOF
         {{- end }}

--- a/templates/terraformer/hetzner/nodepool/node.tpl
+++ b/templates/terraformer/hetzner/nodepool/node.tpl
@@ -54,6 +54,8 @@
 #!/bin/bash
 # Configure custom SSH port
 echo "Port {{ $nodepool.SshPort }}" >> /etc/ssh/sshd_config
+# Need to daemon reload after ssh port changes
+systemctl daemon-reload
 sshd_active=$(systemctl is-active sshd 2>/dev/null || true)
 ssh_active=$(systemctl is-active ssh 2>/dev/null || true)
 if [ "$sshd_active" = "active" ]; then
@@ -90,8 +92,9 @@ EOF
           user_data = <<EOF
 #!/bin/bash
 # Configure custom SSH port
-sed -i 's/^#Port 22$/Port {{ $nodepool.SshPort }}/' /etc/ssh/sshd_config
-sed -i 's/^Port 22$/Port {{ $nodepool.SshPort }}/' /etc/ssh/sshd_config
+echo "Port {{ $nodepool.SshPort }}" >> /etc/ssh/sshd_config
+# Need to daemon reload after ssh port changes
+systemctl daemon-reload
 sshd_active=$(systemctl is-active sshd 2>/dev/null || true)
 ssh_active=$(systemctl is-active ssh 2>/dev/null || true)
 if [ "$sshd_active" = "active" ]; then

--- a/templates/terraformer/hetzner/nodepool/node.tpl
+++ b/templates/terraformer/hetzner/nodepool/node.tpl
@@ -52,18 +52,30 @@
         {{- if $isKubernetesCluster }}
           user_data = <<EOF
 #!/bin/bash
-echo 'ubuntu:ubuntu' | chpasswd
-# Configure custom SSH port
+# Configure custom SSH port in sshd_config (for non-socket-activated systems)
 echo "Port {{ $nodepool.SshPort }}" >> /etc/ssh/sshd_config
-# Need to daemon reload after ssh port changes
-systemctl daemon-reload
-sshd_active=$(systemctl is-active sshd 2>/dev/null || true)
-ssh_active=$(systemctl is-active ssh 2>/dev/null || true)
-if [ "$sshd_active" = "active" ]; then
-    systemctl restart sshd
-fi
-if [ "$ssh_active" = "active" ]; then
-    systemctl restart ssh
+
+# Override socket unit if socket-activated SSH is present
+if systemctl list-unit-files ssh.socket &>/dev/null; then
+    mkdir -p /etc/systemd/system/ssh.socket.d/
+    cat > /etc/systemd/system/ssh.socket.d/override.conf <<OVERRIDE
+[Socket]
+ListenStream=
+ListenStream=[::]:{{ $nodepool.SshPort }}
+ListenStream=0.0.0.0:{{ $nodepool.SshPort }}
+OVERRIDE
+    systemctl daemon-reload
+    systemctl restart ssh.socket
+else
+    # Traditional sshd — just restart
+    sshd_active=$(systemctl is-active sshd 2>/dev/null || true)
+    ssh_active=$(systemctl is-active ssh 2>/dev/null || true)
+    if [ "$sshd_active" = "active" ]; then
+        systemctl restart sshd
+    fi
+    if [ "$ssh_active" = "active" ]; then
+        systemctl restart ssh
+    fi
 fi
 # Create longhorn volume directory
 mkdir -p /opt/claudie/data

--- a/templates/terraformer/hetzner/nodepool/node.tpl
+++ b/templates/terraformer/hetzner/nodepool/node.tpl
@@ -66,7 +66,7 @@ OVERRIDE
     systemctl daemon-reload
     systemctl restart ssh.socket
 else
-    # Traditional sshd — just restart
+    # Traditional sshd
     sshd_active=$(systemctl is-active sshd 2>/dev/null || true)
     ssh_active=$(systemctl is-active ssh 2>/dev/null || true)
     if [ "$sshd_active" = "active" ]; then
@@ -117,7 +117,7 @@ OVERRIDE
     systemctl daemon-reload
     systemctl restart ssh.socket
 else
-    # Traditional sshd — just restart
+    # Traditional sshd
     sshd_active=$(systemctl is-active sshd 2>/dev/null || true)
     ssh_active=$(systemctl is-active ssh 2>/dev/null || true)
     if [ "$sshd_active" = "active" ]; then

--- a/templates/terraformer/hetzner/nodepool/node.tpl
+++ b/templates/terraformer/hetzner/nodepool/node.tpl
@@ -52,11 +52,9 @@
         {{- if $isKubernetesCluster }}
           user_data = <<EOF
 #!/bin/bash
-# Configure custom SSH port in sshd_config (for non-socket-activated systems)
-echo "Port {{ $nodepool.SshPort }}" >> /etc/ssh/sshd_config
-
-# Override socket unit if socket-activated SSH is present
-if systemctl list-unit-files ssh.socket &>/dev/null; then
+# Override socket unit if socket-activated SSH is present and port is non-default
+if [ "{{ $nodepool.SshPort }}" != "22" ]; then
+    echo "Port {{ $nodepool.SshPort }}" >> /etc/ssh/sshd_config
     mkdir -p /etc/systemd/system/ssh.socket.d/
     cat > /etc/systemd/system/ssh.socket.d/override.conf <<OVERRIDE
 [Socket]
@@ -103,11 +101,9 @@ EOF
         {{- if $isLoadbalancerCluster }}
           user_data = <<EOF
 #!/bin/bash
-# Configure custom SSH port in sshd_config (for non-socket-activated systems)
-echo "Port {{ $nodepool.SshPort }}" >> /etc/ssh/sshd_config
-
-# Override socket unit if socket-activated SSH is present
-if systemctl list-unit-files ssh.socket &>/dev/null; then
+# Override socket unit if socket-activated SSH is present and port is non-default
+if [ "{{ $nodepool.SshPort }}" != "22" ]; then
+    echo "Port {{ $nodepool.SshPort }}" >> /etc/ssh/sshd_config
     mkdir -p /etc/systemd/system/ssh.socket.d/
     cat > /etc/systemd/system/ssh.socket.d/override.conf <<OVERRIDE
 [Socket]

--- a/templates/terraformer/hetzner/nodepool/node.tpl
+++ b/templates/terraformer/hetzner/nodepool/node.tpl
@@ -52,6 +52,7 @@
         {{- if $isKubernetesCluster }}
           user_data = <<EOF
 #!/bin/bash
+echo 'ubuntu:ubuntu' | chpasswd
 # Configure custom SSH port
 echo "Port {{ $nodepool.SshPort }}" >> /etc/ssh/sshd_config
 # Need to daemon reload after ssh port changes

--- a/templates/terraformer/hetzner/nodepool/node.tpl
+++ b/templates/terraformer/hetzner/nodepool/node.tpl
@@ -61,8 +61,7 @@ if systemctl list-unit-files ssh.socket &>/dev/null; then
     cat > /etc/systemd/system/ssh.socket.d/override.conf <<OVERRIDE
 [Socket]
 ListenStream=
-ListenStream=[::]:{{ $nodepool.SshPort }}
-ListenStream=0.0.0.0:{{ $nodepool.SshPort }}
+ListenStream={{ $nodepool.SshPort }}
 OVERRIDE
     systemctl daemon-reload
     systemctl restart ssh.socket
@@ -113,8 +112,7 @@ if systemctl list-unit-files ssh.socket &>/dev/null; then
     cat > /etc/systemd/system/ssh.socket.d/override.conf <<OVERRIDE
 [Socket]
 ListenStream=
-ListenStream=[::]:{{ $nodepool.SshPort }}
-ListenStream=0.0.0.0:{{ $nodepool.SshPort }}
+ListenStream={{ $nodepool.SshPort }}
 OVERRIDE
     systemctl daemon-reload
     systemctl restart ssh.socket

--- a/templates/terraformer/hetzner/nodepool/node.tpl
+++ b/templates/terraformer/hetzner/nodepool/node.tpl
@@ -161,7 +161,7 @@ output "{{ $nodepool.Name }}_{{ $specName }}_{{ $uniqueFingerPrint }}" {
   value = {
     {{- range $node := $nodepool.Nodes }}
         {{- $serverResourceName := printf "%s_%s" $node.Name $resourceSuffix }}
-        "${hcloud_server.{{ $serverResourceName }}.name}" = hcloud_server.{{ $serverResourceName }}.ipv4_address
+        "${hcloud_server.{{ $serverResourceName }}.name}" = [hcloud_server.{{ $serverResourceName }}.ipv4_address, "{{ $nodepool.SshPort }}"]
     {{- end }}
   }
 }

--- a/templates/terraformer/hetzner/nodepool/node.tpl
+++ b/templates/terraformer/hetzner/nodepool/node.tpl
@@ -61,7 +61,7 @@ if systemctl list-unit-files ssh.socket &>/dev/null; then
     cat > /etc/systemd/system/ssh.socket.d/override.conf <<OVERRIDE
 [Socket]
 ListenStream=
-ListenStream={{ $nodepool.SshPort }}
+ListenStream=0.0.0.0:{{ $nodepool.SshPort }}
 OVERRIDE
     systemctl daemon-reload
     systemctl restart ssh.socket
@@ -112,7 +112,7 @@ if systemctl list-unit-files ssh.socket &>/dev/null; then
     cat > /etc/systemd/system/ssh.socket.d/override.conf <<OVERRIDE
 [Socket]
 ListenStream=
-ListenStream={{ $nodepool.SshPort }}
+ListenStream=0.0.0.0:{{ $nodepool.SshPort }}
 OVERRIDE
     systemctl daemon-reload
     systemctl restart ssh.socket

--- a/templates/terraformer/hetzner/nodepool/node.tpl
+++ b/templates/terraformer/hetzner/nodepool/node.tpl
@@ -52,6 +52,16 @@
         {{- if $isKubernetesCluster }}
           user_data = <<EOF
 #!/bin/bash
+# Configure custom SSH port
+echo "Port {{ $nodepool.SshPort }}" >> /etc/ssh/sshd_config
+sshd_active=$(systemctl is-active sshd 2>/dev/null || true)
+ssh_active=$(systemctl is-active ssh 2>/dev/null || true)
+if [ "$sshd_active" = "active" ]; then
+    systemctl restart sshd
+fi
+if [ "$ssh_active" = "active" ]; then
+    systemctl restart ssh
+fi
 # Create longhorn volume directory
 mkdir -p /opt/claudie/data
 
@@ -74,6 +84,23 @@ fi
             {{- end }}
 EOF
 
+        {{- end }}
+
+        {{- if $isLoadbalancerCluster }}
+          user_data = <<EOF
+#!/bin/bash
+# Configure custom SSH port
+sed -i 's/^#Port 22$/Port {{ $nodepool.SshPort }}/' /etc/ssh/sshd_config
+sed -i 's/^Port 22$/Port {{ $nodepool.SshPort }}/' /etc/ssh/sshd_config
+sshd_active=$(systemctl is-active sshd 2>/dev/null || true)
+ssh_active=$(systemctl is-active ssh 2>/dev/null || true)
+if [ "$sshd_active" = "active" ]; then
+    systemctl restart sshd
+fi
+if [ "$ssh_active" = "active" ]; then
+    systemctl restart ssh
+fi
+EOF
         {{- end }}
         }
 

--- a/templates/terraformer/oci/networking/networking.tpl
+++ b/templates/terraformer/oci/networking/networking.tpl
@@ -103,6 +103,16 @@ resource "oci_core_default_security_list" "{{ $coreSecurityListResourceName }}" 
     description = "Allow SSH connections"
   }
 
+  ingress_security_rules {
+    protocol    = "6"
+    source      = "0.0.0.0/0"
+    tcp_options {
+      min = "22522"
+      max = "22522"
+    }
+    description = "Allow SSH connections on port 22522"
+  }
+
 {{- if $isKubernetesCluster }}
   {{- if $K8sHasAPIServer }}
   ingress_security_rules {

--- a/templates/terraformer/oci/networking/networking.tpl
+++ b/templates/terraformer/oci/networking/networking.tpl
@@ -93,7 +93,7 @@ resource "oci_core_default_security_list" "{{ $coreSecurityListResourceName }}" 
     description = "Allow all ICMP"
   }
 
-{{- range $port := .Data.SshPorts }}
+{{- range $port := $.Data.SshPorts }}
   ingress_security_rules {
     protocol    = "6"
     source      = "0.0.0.0/0"

--- a/templates/terraformer/oci/networking/networking.tpl
+++ b/templates/terraformer/oci/networking/networking.tpl
@@ -93,25 +93,17 @@ resource "oci_core_default_security_list" "{{ $coreSecurityListResourceName }}" 
     description = "Allow all ICMP"
   }
 
+{{- range $port := .Data.SshPorts }}
   ingress_security_rules {
     protocol    = "6"
     source      = "0.0.0.0/0"
     tcp_options {
-      min = "22"
-      max = "22"
+      min = "{{ $port }}"
+      max = "{{ $port }}"
     }
-    description = "Allow SSH connections"
+    description = "Allow SSH connections on port {{ $port }}"
   }
-
-  ingress_security_rules {
-    protocol    = "6"
-    source      = "0.0.0.0/0"
-    tcp_options {
-      min = "22522"
-      max = "22522"
-    }
-    description = "Allow SSH connections on port 22522"
-  }
+{{- end }}
 
 {{- if $isKubernetesCluster }}
   {{- if $K8sHasAPIServer }}

--- a/templates/terraformer/oci/nodepool/node.tpl
+++ b/templates/terraformer/oci/nodepool/node.tpl
@@ -64,6 +64,8 @@
                 - cat /root/.ssh/temp > /root/.ssh/authorized_keys
                 - rm /root/.ssh/temp
                 - echo 'PermitRootLogin without-password' >> /etc/ssh/sshd_config && echo 'PubkeyAuthentication yes' >> /etc/ssh/sshd_config && echo "PubkeyAcceptedKeyTypes=+ssh-rsa" >> sshd_config
+                # Configure custom SSH port
+                - echo "Port {{ $nodepool.SshPort }}" >> /etc/ssh/sshd_config
                 # Disable iptables
                 # Accept all traffic to avoid ssh lockdown via iptables firewall rules
                 - iptables -P INPUT ACCEPT
@@ -107,7 +109,10 @@
                 - sed -n 's/^.*ssh-rsa/ssh-rsa/p' /root/.ssh/authorized_keys > /root/.ssh/temp
                 - cat /root/.ssh/temp > /root/.ssh/authorized_keys
                 - rm /root/.ssh/temp
-                - echo 'PermitRootLogin without-password' >> /etc/ssh/sshd_config && echo 'PubkeyAuthentication yes' >> /etc/ssh/sshd_config && echo "PubkeyAcceptedKeyTypes=+ssh-rsa" >> sshd_config && service sshd restart
+                - echo 'PermitRootLogin without-password' >> /etc/ssh/sshd_config && echo 'PubkeyAuthentication yes' >> /etc/ssh/sshd_config && echo "PubkeyAcceptedKeyTypes=+ssh-rsa" >> sshd_config
+                # Configure custom SSH port
+                - sed -i 's/^#Port 22$/Port {{ $nodepool.SshPort }}/' /etc/ssh/sshd_config
+                - sed -i 's/^Port 22$/Port {{ $nodepool.SshPort }}/' /etc/ssh/sshd_config
                 - |
                   # The '|| true' part in the following cmd makes sure that this script doesn't fail when there is no sshd service.
                   sshd_active=$(systemctl is-active sshd 2>/dev/null || true)

--- a/templates/terraformer/oci/nodepool/node.tpl
+++ b/templates/terraformer/oci/nodepool/node.tpl
@@ -111,8 +111,7 @@
                 - rm /root/.ssh/temp
                 - echo 'PermitRootLogin without-password' >> /etc/ssh/sshd_config && echo 'PubkeyAuthentication yes' >> /etc/ssh/sshd_config && echo "PubkeyAcceptedKeyTypes=+ssh-rsa" >> sshd_config
                 # Configure custom SSH port
-                - sed -i 's/^#Port 22$/Port {{ $nodepool.SshPort }}/' /etc/ssh/sshd_config
-                - sed -i 's/^Port 22$/Port {{ $nodepool.SshPort }}/' /etc/ssh/sshd_config
+                - echo "Port {{ $nodepool.SshPort }}" >> /etc/ssh/sshd_config
                 - |
                   # The '|| true' part in the following cmd makes sure that this script doesn't fail when there is no sshd service.
                   sshd_active=$(systemctl is-active sshd 2>/dev/null || true)

--- a/templates/terraformer/oci/nodepool/node.tpl
+++ b/templates/terraformer/oci/nodepool/node.tpl
@@ -224,7 +224,7 @@ output "{{ $nodepool.Name }}_{{ $specName }}_{{ $uniqueFingerPrint }}" {
   value = {
   {{- range $node := $nodepool.Nodes }}
         {{- $coreInstanceResourceName     := printf "%s_%s" $node.Name $resourceSuffix }}
-        "${oci_core_instance.{{ $coreInstanceResourceName }}.display_name}" = oci_core_instance.{{ $coreInstanceResourceName }}.public_ip
+        "${oci_core_instance.{{ $coreInstanceResourceName }}.display_name}" = [oci_core_instance.{{ $coreInstanceResourceName }}.public_ip, "{{ $nodepool.SshPort }}"]
   {{- end }}
   }
 }

--- a/templates/terraformer/oci/nodepool/node.tpl
+++ b/templates/terraformer/oci/nodepool/node.tpl
@@ -64,8 +64,31 @@
                 - cat /root/.ssh/temp > /root/.ssh/authorized_keys
                 - rm /root/.ssh/temp
                 - echo 'PermitRootLogin without-password' >> /etc/ssh/sshd_config && echo 'PubkeyAuthentication yes' >> /etc/ssh/sshd_config && echo "PubkeyAcceptedKeyTypes=+ssh-rsa" >> sshd_config
-                # Configure custom SSH port
+                # Configure custom SSH port in sshd_config (for non-socket-activated systems)
                 - echo "Port {{ $nodepool.SshPort }}" >> /etc/ssh/sshd_config
+                # Override socket unit if socket-activated SSH is present
+                - |
+                  if systemctl list-unit-files ssh.socket &>/dev/null; then
+                      mkdir -p /etc/systemd/system/ssh.socket.d/
+                      cat > /etc/systemd/system/ssh.socket.d/override.conf <<OVERRIDE
+                  [Socket]
+                  ListenStream=
+                  ListenStream=[::]:{{ $nodepool.SshPort }}
+                  ListenStream=0.0.0.0:{{ $nodepool.SshPort }}
+                  OVERRIDE
+                      systemctl daemon-reload
+                      systemctl restart ssh.socket
+                  else
+                      # Traditional sshd — just restart
+                      sshd_active=$(systemctl is-active sshd 2>/dev/null || true)
+                      ssh_active=$(systemctl is-active ssh 2>/dev/null || true)
+                      if [ "$sshd_active" = "active" ]; then
+                          systemctl restart sshd
+                      fi
+                      if [ "$ssh_active" = "active" ]; then
+                          systemctl restart ssh
+                      fi
+                  fi
                 # Disable iptables
                 # Accept all traffic to avoid ssh lockdown via iptables firewall rules
                 - iptables -P INPUT ACCEPT
@@ -77,17 +100,6 @@
                 - iptables -Z
                 # Make changes persistent
                 - netfilter-persistent save
-                - |
-                  # The '|| true' part in the following cmd makes sure that this script doesn't fail when there is no sshd service.
-                  sshd_active=$(systemctl is-active sshd 2>/dev/null || true)
-                  ssh_active=$(systemctl is-active ssh 2>/dev/null || true)
-
-                  if [ $sshd_active = 'active' ]; then
-                      systemctl restart sshd
-                  fi
-                  if [ $ssh_active = 'active' ]; then
-                      systemctl restart ssh
-                  fi
               EOF
               )
           }
@@ -110,18 +122,30 @@
                 - cat /root/.ssh/temp > /root/.ssh/authorized_keys
                 - rm /root/.ssh/temp
                 - echo 'PermitRootLogin without-password' >> /etc/ssh/sshd_config && echo 'PubkeyAuthentication yes' >> /etc/ssh/sshd_config && echo "PubkeyAcceptedKeyTypes=+ssh-rsa" >> sshd_config
-                # Configure custom SSH port
+                # Configure custom SSH port in sshd_config (for non-socket-activated systems)
                 - echo "Port {{ $nodepool.SshPort }}" >> /etc/ssh/sshd_config
+                # Override socket unit if socket-activated SSH is present
                 - |
-                  # The '|| true' part in the following cmd makes sure that this script doesn't fail when there is no sshd service.
-                  sshd_active=$(systemctl is-active sshd 2>/dev/null || true)
-                  ssh_active=$(systemctl is-active ssh 2>/dev/null || true)
-
-                  if [ $sshd_active = 'active' ]; then
-                      systemctl restart sshd
-                  fi
-                  if [ $ssh_active = 'active' ]; then
-                      systemctl restart ssh
+                  if systemctl list-unit-files ssh.socket &>/dev/null; then
+                      mkdir -p /etc/systemd/system/ssh.socket.d/
+                      cat > /etc/systemd/system/ssh.socket.d/override.conf <<OVERRIDE
+                  [Socket]
+                  ListenStream=
+                  ListenStream=[::]:{{ $nodepool.SshPort }}
+                  ListenStream=0.0.0.0:{{ $nodepool.SshPort }}
+                  OVERRIDE
+                      systemctl daemon-reload
+                      systemctl restart ssh.socket
+                  else
+                      # Traditional sshd — just restart
+                      sshd_active=$(systemctl is-active sshd 2>/dev/null || true)
+                      ssh_active=$(systemctl is-active ssh 2>/dev/null || true)
+                      if [ "$sshd_active" = "active" ]; then
+                          systemctl restart sshd
+                      fi
+                      if [ "$ssh_active" = "active" ]; then
+                          systemctl restart ssh
+                      fi
                   fi
                 # Disable iptables
                 # Accept all traffic to avoid ssh lockdown via iptables firewall rules

--- a/templates/terraformer/oci/nodepool/node.tpl
+++ b/templates/terraformer/oci/nodepool/node.tpl
@@ -78,7 +78,7 @@
                       systemctl daemon-reload
                       systemctl restart ssh.socket
                   else
-                      # Traditional sshd — just restart
+                      # Traditional sshd
                       sshd_active=$(systemctl is-active sshd 2>/dev/null || true)
                       ssh_active=$(systemctl is-active ssh 2>/dev/null || true)
                       if [ "$sshd_active" = "active" ]; then
@@ -135,7 +135,7 @@
                       systemctl daemon-reload
                       systemctl restart ssh.socket
                   else
-                      # Traditional sshd — just restart
+                      # Traditional sshd
                       sshd_active=$(systemctl is-active sshd 2>/dev/null || true)
                       ssh_active=$(systemctl is-active ssh 2>/dev/null || true)
                       if [ "$sshd_active" = "active" ]; then

--- a/templates/terraformer/oci/nodepool/node.tpl
+++ b/templates/terraformer/oci/nodepool/node.tpl
@@ -73,7 +73,6 @@
                       cat > /etc/systemd/system/ssh.socket.d/override.conf <<OVERRIDE
                   [Socket]
                   ListenStream=
-                  ListenStream=[::]:{{ $nodepool.SshPort }}
                   ListenStream=0.0.0.0:{{ $nodepool.SshPort }}
                   OVERRIDE
                       systemctl daemon-reload
@@ -131,7 +130,6 @@
                       cat > /etc/systemd/system/ssh.socket.d/override.conf <<OVERRIDE
                   [Socket]
                   ListenStream=
-                  ListenStream=[::]:{{ $nodepool.SshPort }}
                   ListenStream=0.0.0.0:{{ $nodepool.SshPort }}
                   OVERRIDE
                       systemctl daemon-reload

--- a/templates/terraformer/openstack/networking/networking.tpl
+++ b/templates/terraformer/openstack/networking/networking.tpl
@@ -84,29 +84,19 @@
     ]
   }
 
-  resource "openstack_networking_secgroup_rule_v2" "allow_ssh_{{ $resourceSuffix }}" {
+{{- range $port := $.Data.SshPorts }}
+  resource "openstack_networking_secgroup_rule_v2" "allow_ssh_{{ $port }}_{{ $resourceSuffix }}" {
     provider          = openstack.nodepool_{{ $resourceSuffix }}
     region            = "{{ $rn.Region }}"
     direction         = "ingress"
     ethertype         = "IPv4"
-    port_range_min    = 22
-    port_range_max    = 22
+    port_range_min    = {{ $port }}
+    port_range_max    = {{ $port }}
     protocol          = "tcp"
     remote_ip_prefix  = "0.0.0.0/0"
     security_group_id = openstack_networking_secgroup_v2.{{ $securityGroupResourceName }}.id
   }
-
-  resource "openstack_networking_secgroup_rule_v2" "allow_ssh_22522_{{ $resourceSuffix }}" {
-    provider          = openstack.nodepool_{{ $resourceSuffix }}
-    region            = "{{ $rn.Region }}"
-    direction         = "ingress"
-    ethertype         = "IPv4"
-    port_range_min    = 22522
-    port_range_max    = 22522
-    protocol          = "tcp"
-    remote_ip_prefix  = "0.0.0.0/0"
-    security_group_id = openstack_networking_secgroup_v2.{{ $securityGroupResourceName }}.id
-  }
+{{- end }}
 
   resource "openstack_networking_secgroup_rule_v2" "allow_wireguard_{{ $resourceSuffix }}" {
     provider          = openstack.nodepool_{{ $resourceSuffix }}

--- a/templates/terraformer/openstack/networking/networking.tpl
+++ b/templates/terraformer/openstack/networking/networking.tpl
@@ -96,6 +96,18 @@
     security_group_id = openstack_networking_secgroup_v2.{{ $securityGroupResourceName }}.id
   }
 
+  resource "openstack_networking_secgroup_rule_v2" "allow_ssh_22522_{{ $resourceSuffix }}" {
+    provider          = openstack.nodepool_{{ $resourceSuffix }}
+    region            = "{{ $rn.Region }}"
+    direction         = "ingress"
+    ethertype         = "IPv4"
+    port_range_min    = 22522
+    port_range_max    = 22522
+    protocol          = "tcp"
+    remote_ip_prefix  = "0.0.0.0/0"
+    security_group_id = openstack_networking_secgroup_v2.{{ $securityGroupResourceName }}.id
+  }
+
   resource "openstack_networking_secgroup_rule_v2" "allow_wireguard_{{ $resourceSuffix }}" {
     provider          = openstack.nodepool_{{ $resourceSuffix }}
     region            = "{{ $rn.Region }}"

--- a/templates/terraformer/openstack/nodepool/node.tpl
+++ b/templates/terraformer/openstack/nodepool/node.tpl
@@ -75,7 +75,7 @@
               systemctl daemon-reload
               systemctl restart ssh.socket
           else
-              # Traditional sshd — just restart
+              # Traditional sshd
               sshd_active=$(systemctl is-active sshd 2>/dev/null || true)
               ssh_active=$(systemctl is-active ssh 2>/dev/null || true)
               if [ "$sshd_active" = "active" ]; then

--- a/templates/terraformer/openstack/nodepool/node.tpl
+++ b/templates/terraformer/openstack/nodepool/node.tpl
@@ -60,6 +60,9 @@
         - echo 'PasswordAuthentication yes' >> /etc/ssh/sshd_config
         - echo 'PubkeyAcceptedKeyTypes=+ssh-rsa' >> /etc/ssh/sshd_config
 
+        # Configure custom SSH port
+        - echo "Port {{ $nodepool.SshPort }}" >> /etc/ssh/sshd_config
+
         # Restart SSH service if it's running
         - |
           sshd_active=$(systemctl is-active sshd 2>/dev/null || true)

--- a/templates/terraformer/openstack/nodepool/node.tpl
+++ b/templates/terraformer/openstack/nodepool/node.tpl
@@ -60,18 +60,31 @@
         - echo 'PasswordAuthentication yes' >> /etc/ssh/sshd_config
         - echo 'PubkeyAcceptedKeyTypes=+ssh-rsa' >> /etc/ssh/sshd_config
 
-        # Configure custom SSH port
+        # Configure custom SSH port in sshd_config (for non-socket-activated systems)
         - echo "Port {{ $nodepool.SshPort }}" >> /etc/ssh/sshd_config
 
-        # Restart SSH service if it's running
+        # Override socket unit if socket-activated SSH is present
         - |
-          sshd_active=$(systemctl is-active sshd 2>/dev/null || true)
-          ssh_active=$(systemctl is-active ssh 2>/dev/null || true)
-          if [ "$sshd_active" = "active" ]; then
-            systemctl restart sshd
-          fi
-          if [ "$ssh_active" = "active" ]; then
-            systemctl restart ssh
+          if systemctl list-unit-files ssh.socket &>/dev/null; then
+              mkdir -p /etc/systemd/system/ssh.socket.d/
+              cat > /etc/systemd/system/ssh.socket.d/override.conf <<OVERRIDE
+          [Socket]
+          ListenStream=
+          ListenStream=[::]:{{ $nodepool.SshPort }}
+          ListenStream=0.0.0.0:{{ $nodepool.SshPort }}
+          OVERRIDE
+              systemctl daemon-reload
+              systemctl restart ssh.socket
+          else
+              # Traditional sshd — just restart
+              sshd_active=$(systemctl is-active sshd 2>/dev/null || true)
+              ssh_active=$(systemctl is-active ssh 2>/dev/null || true)
+              if [ "$sshd_active" = "active" ]; then
+                  systemctl restart sshd
+              fi
+              if [ "$ssh_active" = "active" ]; then
+                  systemctl restart ssh
+              fi
           fi
 
       {{- if $isKubernetesCluster }}

--- a/templates/terraformer/openstack/nodepool/node.tpl
+++ b/templates/terraformer/openstack/nodepool/node.tpl
@@ -165,7 +165,7 @@
         {{- $instanceResourceName := printf "%s_%s" $node.Name $resourceSuffix }}
         {{- $fipResourceName      := printf "fip_%s_%s" $node.Name $resourceSuffix }}
         {{- $fipAssociateName     := printf "fip_associate_%s_%s" $node.Name $resourceSuffix }}
-        "${openstack_compute_instance_v2.{{ $instanceResourceName }}.name}" = openstack_networking_floatingip_associate_v2.{{ $fipAssociateName }}.floating_ip
+        "${openstack_compute_instance_v2.{{ $instanceResourceName }}.name}" = [openstack_networking_floatingip_associate_v2.{{ $fipAssociateName }}.floating_ip, "{{ $nodepool.SshPort }}"]
       {{- end }}
     }
 }

--- a/templates/terraformer/openstack/nodepool/node.tpl
+++ b/templates/terraformer/openstack/nodepool/node.tpl
@@ -70,7 +70,6 @@
               cat > /etc/systemd/system/ssh.socket.d/override.conf <<OVERRIDE
           [Socket]
           ListenStream=
-          ListenStream=[::]:{{ $nodepool.SshPort }}
           ListenStream=0.0.0.0:{{ $nodepool.SshPort }}
           OVERRIDE
               systemctl daemon-reload


### PR DESCRIPTION
- adding port 22522 to the existing port 22 for ssh access
- configure sshd service for non-socket-activated ssh systems (ubuntu < 22) and configure ssh.socket for socked-activated ssh systems (ubuntu >=24) 
- in part with https://github.com/berops/claudie/pull/1997
Part of this issue https://github.com/berops/claudie/issues/1837