### PR TITLE
feat: add CloudRift provider templates

### DIFF
--- a/templates/terraformer/cloudrift/networking/networking.tpl
+++ b/templates/terraformer/cloudrift/networking/networking.tpl
@@ -40,7 +40,8 @@ iptables -A INPUT -p icmp -j ACCEPT
 iptables -A INPUT -i wg0 -j ACCEPT
 # Set default policy to drop everything else
 iptables -P INPUT DROP
-# Block inbound IPv6 traffic
+# Block IPv6 traffic but allow loopback (kube-apiserver uses [::1]:6443 internally)
+ip6tables -A INPUT -i lo -j ACCEPT
 ip6tables -P INPUT DROP
 ip6tables -P FORWARD DROP
 # Persist rules across reboots

--- a/templates/terraformer/cloudrift/networking/networking.tpl
+++ b/templates/terraformer/cloudrift/networking/networking.tpl
@@ -45,7 +45,7 @@ ip6tables -P INPUT DROP
 ip6tables -P FORWARD DROP
 ip6tables -P OUTPUT DROP
 # Persist rules across reboots
-apt-get install -y -qq iptables-persistent > /dev/null 2>&1 || true
+DEBIAN_FRONTEND=noninteractive apt-get install -y -qq iptables-persistent > /dev/null 2>&1 || true
 iptables-save > /etc/iptables/rules.v4
 FWSCRIPT
 }

--- a/templates/terraformer/cloudrift/networking/networking.tpl
+++ b/templates/terraformer/cloudrift/networking/networking.tpl
@@ -9,27 +9,35 @@
 {{- $resourceSuffix        := printf "%s_%s" $specName $uniqueFingerPrint }}
 
 # CloudRift does not provide cloud-level firewall or networking resources.
-# UFW firewall rules are applied on each VM via startup commands.
-# This template generates the UFW script as a Terraform local
+# Direct iptables rules are used instead of UFW because KubeOne disables UFW
+# during node provisioning. KubeOne does not flush iptables INPUT rules.
+# This template generates the firewall script as a Terraform local
 # so that nodepool/node.tpl can reference it in startup_commands.
 
 locals {
-  cloudrift_ufw_script_{{ $resourceSuffix }} = <<-UFWSCRIPT
-apt-get update -qq > /dev/null 2>&1 || true
-apt-get install -y -qq ufw > /dev/null 2>&1 || true
-ufw default deny incoming
-ufw default allow outgoing
-ufw allow 22/tcp
-ufw allow 51820/udp
+  cloudrift_firewall_script_{{ $resourceSuffix }} = <<-FWSCRIPT
+# Allow established connections and loopback
+iptables -A INPUT -m state --state ESTABLISHED,RELATED -j ACCEPT
+iptables -A INPUT -i lo -j ACCEPT
+# Allow SSH
+iptables -A INPUT -p tcp --dport 22 -j ACCEPT
+# Allow WireGuard
+iptables -A INPUT -p udp --dport 51820 -j ACCEPT
 {{- if $isKubernetesCluster }}
-ufw allow 6443/tcp
+# Allow K8s API server
+iptables -A INPUT -p tcp --dport 6443 -j ACCEPT
+# Allow kubelet API
+iptables -A INPUT -p tcp --dport 10250 -j ACCEPT
 {{- end }}
 {{- if $isLoadbalancerCluster }}
   {{- range $role := $LoadBalancerRoles }}
-ufw allow {{ $role.Port }}/{{ lower $role.Protocol }}
+iptables -A INPUT -p {{ lower $role.Protocol }} --dport {{ $role.Port }} -j ACCEPT
   {{- end }}
 {{- end }}
-ufw --force enable
-systemctl enable ufw
-UFWSCRIPT
+# Drop everything else
+iptables -A INPUT -j DROP
+# Persist rules across reboots
+apt-get install -y -qq iptables-persistent > /dev/null 2>&1 || true
+iptables-save > /etc/iptables/rules.v4
+FWSCRIPT
 }

--- a/templates/terraformer/cloudrift/networking/networking.tpl
+++ b/templates/terraformer/cloudrift/networking/networking.tpl
@@ -15,7 +15,8 @@
 
 locals {
   cloudrift_ufw_script_{{ $resourceSuffix }} = <<-UFWSCRIPT
-apt-get update -qq && apt-get install -y -qq ufw > /dev/null 2>&1
+apt-get update -qq > /dev/null 2>&1 || true
+apt-get install -y -qq ufw > /dev/null 2>&1 || true
 ufw default deny incoming
 ufw default allow outgoing
 ufw allow 22/tcp
@@ -29,5 +30,6 @@ ufw allow {{ $role.Port }}/{{ lower $role.Protocol }}
   {{- end }}
 {{- end }}
 ufw --force enable
+systemctl enable ufw
 UFWSCRIPT
 }

--- a/templates/terraformer/cloudrift/networking/networking.tpl
+++ b/templates/terraformer/cloudrift/networking/networking.tpl
@@ -1,0 +1,35 @@
+{{- $clusterName           := .Data.ClusterData.ClusterName}}
+{{- $clusterHash           := .Data.ClusterData.ClusterHash}}
+{{- $specName              := .Data.Provider.SpecName }}
+{{- $uniqueFingerPrint     := .Fingerprint }}
+{{- $isKubernetesCluster   := eq .Data.ClusterData.ClusterType "K8s" }}
+{{- $isLoadbalancerCluster := eq .Data.ClusterData.ClusterType "LB" }}
+{{- $LoadBalancerRoles     := .Data.LBData.Roles }}
+{{- $K8sHasAPIServer       := .Data.K8sData.HasAPIServer }}
+{{- $resourceSuffix        := printf "%s_%s" $specName $uniqueFingerPrint }}
+
+# CloudRift does not provide cloud-level firewall or networking resources.
+# UFW firewall rules are applied on each VM via startup commands.
+# This template generates the UFW script as a Terraform local
+# so that nodepool/node.tpl can reference it in startup_commands.
+
+locals {
+  cloudrift_ufw_script_{{ $resourceSuffix }} = <<-UFWSCRIPT
+apt-get update -qq && apt-get install -y -qq ufw > /dev/null 2>&1
+ufw default deny incoming
+ufw default allow outgoing
+ufw allow 22/tcp
+ufw allow 51820/udp
+{{- if $isKubernetesCluster }}
+  {{- if $K8sHasAPIServer }}
+ufw allow 6443/tcp
+  {{- end }}
+{{- end }}
+{{- if $isLoadbalancerCluster }}
+  {{- range $role := $LoadBalancerRoles }}
+ufw allow {{ $role.Port }}/{{ lower $role.Protocol }}
+  {{- end }}
+{{- end }}
+ufw --force enable
+UFWSCRIPT
+}

--- a/templates/terraformer/cloudrift/networking/networking.tpl
+++ b/templates/terraformer/cloudrift/networking/networking.tpl
@@ -40,10 +40,9 @@ iptables -A INPUT -p icmp -j ACCEPT
 iptables -A INPUT -i wg0 -j ACCEPT
 # Set default policy to drop everything else
 iptables -P INPUT DROP
-# Block all IPv6 traffic
+# Block inbound IPv6 traffic
 ip6tables -P INPUT DROP
 ip6tables -P FORWARD DROP
-ip6tables -P OUTPUT DROP
 # Persist rules across reboots
 DEBIAN_FRONTEND=noninteractive apt-get install -y -qq iptables-persistent > /dev/null 2>&1 || true
 iptables-save > /etc/iptables/rules.v4

--- a/templates/terraformer/cloudrift/networking/networking.tpl
+++ b/templates/terraformer/cloudrift/networking/networking.tpl
@@ -34,10 +34,16 @@ iptables -A INPUT -p tcp --dport 10250 -j ACCEPT
 iptables -A INPUT -p {{ lower $role.Protocol }} --dport {{ $role.Port }} -j ACCEPT
   {{- end }}
 {{- end }}
+# Allow ICMP
+iptables -A INPUT -p icmp -j ACCEPT
 # Allow all traffic on WireGuard tunnel interface
 iptables -A INPUT -i wg0 -j ACCEPT
-# Drop everything else
-iptables -A INPUT -j DROP
+# Set default policy to drop everything else
+iptables -P INPUT DROP
+# Block all IPv6 traffic
+ip6tables -P INPUT DROP
+ip6tables -P FORWARD DROP
+ip6tables -P OUTPUT DROP
 # Persist rules across reboots
 apt-get install -y -qq iptables-persistent > /dev/null 2>&1 || true
 iptables-save > /etc/iptables/rules.v4

--- a/templates/terraformer/cloudrift/networking/networking.tpl
+++ b/templates/terraformer/cloudrift/networking/networking.tpl
@@ -34,6 +34,8 @@ iptables -A INPUT -p tcp --dport 10250 -j ACCEPT
 iptables -A INPUT -p {{ lower $role.Protocol }} --dport {{ $role.Port }} -j ACCEPT
   {{- end }}
 {{- end }}
+# Allow all traffic on WireGuard tunnel interface
+iptables -A INPUT -i wg0 -j ACCEPT
 # Drop everything else
 iptables -A INPUT -j DROP
 # Persist rules across reboots

--- a/templates/terraformer/cloudrift/networking/networking.tpl
+++ b/templates/terraformer/cloudrift/networking/networking.tpl
@@ -21,9 +21,7 @@ ufw default allow outgoing
 ufw allow 22/tcp
 ufw allow 51820/udp
 {{- if $isKubernetesCluster }}
-  {{- if $K8sHasAPIServer }}
 ufw allow 6443/tcp
-  {{- end }}
 {{- end }}
 {{- if $isLoadbalancerCluster }}
   {{- range $role := $LoadBalancerRoles }}

--- a/templates/terraformer/cloudrift/nodepool/node.tpl
+++ b/templates/terraformer/cloudrift/nodepool/node.tpl
@@ -59,8 +59,8 @@ if [ -n "$PUBLIC_IP" ] && [ -n "$PRIVATE_IP" ]; then
     iptables -t nat -A OUTPUT -d "$PUBLIC_IP" -j DNAT --to-destination "$PRIVATE_IP"
 fi
 
-# Configure UFW firewall
-${local.cloudrift_ufw_script_{{ $resourceSuffix }}}
+# Configure iptables firewall (not UFW — KubeOne disables UFW)
+${local.cloudrift_firewall_script_{{ $resourceSuffix }}}
 
 {{- if $isKubernetesCluster }}
 

--- a/templates/terraformer/cloudrift/nodepool/node.tpl
+++ b/templates/terraformer/cloudrift/nodepool/node.tpl
@@ -36,8 +36,8 @@
 # Enable root SSH access
 mkdir -p /root/.ssh
 chmod 700 /root/.ssh
-if [ -f /home/ubuntu/.ssh/authorized_keys ]; then
-    sed -n 's/^.*ssh-rsa/ssh-rsa/p' /home/ubuntu/.ssh/authorized_keys > /root/.ssh/authorized_keys
+if [ -f /home/riftuser/.ssh/authorized_keys ]; then
+    sed -n 's/^.*ssh-rsa/ssh-rsa/p' /home/riftuser/.ssh/authorized_keys > /root/.ssh/authorized_keys
     chmod 600 /root/.ssh/authorized_keys
 fi
 echo 'PermitRootLogin without-password' >> /etc/ssh/sshd_config

--- a/templates/terraformer/cloudrift/nodepool/node.tpl
+++ b/templates/terraformer/cloudrift/nodepool/node.tpl
@@ -31,7 +31,7 @@
           ssh_key_id    = cloudrift_ssh_key.{{ $sshKeyResourceName }}.id
 
           metadata = {
-            startup_commands = <<-SCRIPT
+            startup_commands = base64encode(<<-SCRIPT
 #!/bin/bash
 # Enable root SSH access
 mkdir -p /root/.ssh
@@ -61,6 +61,7 @@ ${local.cloudrift_ufw_script_{{ $resourceSuffix }}}
 mkdir -p /opt/claudie/data
 {{- end }}
 SCRIPT
+            )
           }
         }
 

--- a/templates/terraformer/cloudrift/nodepool/node.tpl
+++ b/templates/terraformer/cloudrift/nodepool/node.tpl
@@ -1,0 +1,77 @@
+{{- $clusterName           := .Data.ClusterData.ClusterName}}
+{{- $clusterHash           := .Data.ClusterData.ClusterHash}}
+{{- $uniqueFingerPrint     := .Fingerprint }}
+{{- $isKubernetesCluster   := eq .Data.ClusterData.ClusterType "K8s" }}
+{{- $isLoadbalancerCluster := eq .Data.ClusterData.ClusterType "LB" }}
+
+
+{{- range $nodepool := .Data.NodePools }}
+
+{{- $specName       := $nodepool.Details.Provider.SpecName }}
+{{- $resourceSuffix := printf "%s_%s" $specName $uniqueFingerPrint }}
+
+{{- $sshKeyResourceName := printf "key_%s_%s" $nodepool.Name $resourceSuffix }}
+{{- $sshKeyName         := printf "key-%s-%s-%s" $nodepool.Name $clusterHash $specName }}
+
+    resource "cloudrift_ssh_key" "{{ $sshKeyResourceName }}" {
+      provider   = cloudrift.nodepool_{{ $resourceSuffix }}
+      name       = "{{ $sshKeyName }}"
+      public_key = file("./{{ $nodepool.Name }}")
+    }
+
+    {{- range $node := $nodepool.Nodes }}
+
+        {{- $serverResourceName := printf "%s_%s" $node.Name $resourceSuffix }}
+
+        resource "cloudrift_virtual_machine" "{{ $serverResourceName }}" {
+          provider      = cloudrift.nodepool_{{ $resourceSuffix }}
+          recipe        = "{{ $nodepool.Details.Image }}"
+          datacenter    = "{{ $nodepool.Details.Region }}"
+          instance_type = "{{ $nodepool.Details.ServerType }}"
+          ssh_key_id    = cloudrift_ssh_key.{{ $sshKeyResourceName }}.id
+
+          metadata {
+            startup_commands = <<-SCRIPT
+#!/bin/bash
+# Enable root SSH access
+mkdir -p /root/.ssh
+chmod 700 /root/.ssh
+if [ -f /home/ubuntu/.ssh/authorized_keys ]; then
+    sed -n 's/^.*ssh-rsa/ssh-rsa/p' /home/ubuntu/.ssh/authorized_keys > /root/.ssh/authorized_keys
+    chmod 600 /root/.ssh/authorized_keys
+fi
+echo 'PermitRootLogin without-password' >> /etc/ssh/sshd_config
+echo 'PubkeyAuthentication yes' >> /etc/ssh/sshd_config
+echo 'PubkeyAcceptedKeyTypes=+ssh-rsa' >> /etc/ssh/sshd_config
+sshd_active=$(systemctl is-active sshd 2>/dev/null || true)
+ssh_active=$(systemctl is-active ssh 2>/dev/null || true)
+if [ "$sshd_active" = "active" ]; then
+    systemctl restart sshd
+fi
+if [ "$ssh_active" = "active" ]; then
+    systemctl restart ssh
+fi
+
+# Configure UFW firewall
+${local.cloudrift_ufw_script_{{ $resourceSuffix }}}
+
+{{- if $isKubernetesCluster }}
+
+# Create longhorn volume directory
+mkdir -p /opt/claudie/data
+{{- end }}
+SCRIPT
+          }
+        }
+
+    {{- end }}
+
+output "{{ $nodepool.Name }}_{{ $specName }}_{{ $uniqueFingerPrint }}" {
+  value = {
+    {{- range $node := $nodepool.Nodes }}
+        {{- $serverResourceName := printf "%s_%s" $node.Name $resourceSuffix }}
+        "{{ $node.Name }}" = cloudrift_virtual_machine.{{ $serverResourceName }}.public_ip
+    {{- end }}
+  }
+}
+{{- end }}

--- a/templates/terraformer/cloudrift/nodepool/node.tpl
+++ b/templates/terraformer/cloudrift/nodepool/node.tpl
@@ -52,6 +52,13 @@ if [ "$ssh_active" = "active" ]; then
     systemctl restart ssh
 fi
 
+# Fix NAT hairpinning - allow node to reach its own public IP
+PUBLIC_IP=$(curl -4 -s --connect-timeout 5 ifconfig.me)
+PRIVATE_IP=$(ip route get 1.1.1.1 | awk '{print $7; exit}')
+if [ -n "$PUBLIC_IP" ] && [ -n "$PRIVATE_IP" ]; then
+    iptables -t nat -A OUTPUT -d "$PUBLIC_IP" -j DNAT --to-destination "$PRIVATE_IP"
+fi
+
 # Configure UFW firewall
 ${local.cloudrift_ufw_script_{{ $resourceSuffix }}}
 

--- a/templates/terraformer/cloudrift/nodepool/node.tpl
+++ b/templates/terraformer/cloudrift/nodepool/node.tpl
@@ -30,7 +30,7 @@
           instance_type = "{{ $nodepool.Details.ServerType }}"
           ssh_key_id    = cloudrift_ssh_key.{{ $sshKeyResourceName }}.id
 
-          metadata {
+          metadata = {
             startup_commands = <<-SCRIPT
 #!/bin/bash
 # Enable root SSH access

--- a/templates/terraformer/cloudrift/provider/provider.tpl
+++ b/templates/terraformer/cloudrift/provider/provider.tpl
@@ -1,0 +1,11 @@
+{{- $specName          := .Data.Provider.SpecName }}
+{{- $uniqueFingerPrint := .Fingerprint }}
+{{- $resourceSuffix    := printf "%s_%s" $specName $uniqueFingerPrint }}
+
+provider "cloudrift" {
+  token = file("{{ $specName }}")
+  alias = "nodepool_{{ $resourceSuffix }}"
+{{- if .Data.Provider.GetCloudrift.TeamId }}
+  team_id = "{{ .Data.Provider.GetCloudrift.TeamId }}"
+{{- end }}
+}


### PR DESCRIPTION
## Summary
- Add CloudRift Terraform templates (provider, networking, nodepool)
- UFW firewall via startup_commands (no cloud-level firewall available)
- NAT hairpinning workaround for same-subnet nodes

Related to berops/claudie#1982

**Required by:** berops/claudie#2000 (CloudRift provider implementation)