### PR TITLE
Custom ssh port in terraform template

### DIFF
--- a/templates/terraformer/aws/networking/networking.tpl
+++ b/templates/terraformer/aws/networking/networking.tpl
@@ -86,17 +86,15 @@ resource "aws_security_group_rule" "allow_egress_{{ $resourceSuffix }}" {
 }
 
 
-{{- range $port := $.Data.SshPorts }}
-resource "aws_security_group_rule" "allow_ssh_{{ $port }}_{{ $resourceSuffix }}" {
+resource "aws_security_group_rule" "allow_ssh_{{ $resourceSuffix }}" {
   provider          = aws.nodepool_{{ $resourceSuffix }}
   type              = "ingress"
-  from_port         = {{ $port }}
-  to_port           = {{ $port }}
+  from_port         = 22522
+  to_port           = 22522
   protocol          = "tcp"
   cidr_blocks       = ["0.0.0.0/0"]
   security_group_id = aws_security_group.{{ $securityGroupResourceName }}.id
 }
-{{- end }}
 
 {{- if $isKubernetesCluster  }}
     {{- if $K8sHasAPIServer }}

--- a/templates/terraformer/aws/networking/networking.tpl
+++ b/templates/terraformer/aws/networking/networking.tpl
@@ -11,6 +11,10 @@
 
 {{- $resourceSuffix := printf "%s_%s_%s" $region $specName $uniqueFingerPrint }}
 
+locals {
+  claudie_ssh_port_{{ $resourceSuffix }} = 22522
+}
+
 # Fetch available availability zones for this region
 data "aws_availability_zones" "available_{{ $resourceSuffix }}" {
   provider = aws.nodepool_{{ $resourceSuffix }}
@@ -89,8 +93,8 @@ resource "aws_security_group_rule" "allow_egress_{{ $resourceSuffix }}" {
 resource "aws_security_group_rule" "allow_ssh_{{ $resourceSuffix }}" {
   provider          = aws.nodepool_{{ $resourceSuffix }}
   type              = "ingress"
-  from_port         = 22522
-  to_port           = 22522
+  from_port         = local.claudie_ssh_port_{{ $resourceSuffix }}
+  to_port           = local.claudie_ssh_port_{{ $resourceSuffix }}
   protocol          = "tcp"
   cidr_blocks       = ["0.0.0.0/0"]
   security_group_id = aws_security_group.{{ $securityGroupResourceName }}.id

--- a/templates/terraformer/aws/networking/networking.tpl
+++ b/templates/terraformer/aws/networking/networking.tpl
@@ -86,15 +86,17 @@ resource "aws_security_group_rule" "allow_egress_{{ $resourceSuffix }}" {
 }
 
 
-resource "aws_security_group_rule" "allow_ssh_{{ $resourceSuffix }}" {
+{{- range $port := $.Data.SshPorts }}
+resource "aws_security_group_rule" "allow_ssh_{{ $port }}_{{ $resourceSuffix }}" {
   provider          = aws.nodepool_{{ $resourceSuffix }}
   type              = "ingress"
-  from_port         = 22
-  to_port           = 22
+  from_port         = {{ $port }}
+  to_port           = {{ $port }}
   protocol          = "tcp"
   cidr_blocks       = ["0.0.0.0/0"]
   security_group_id = aws_security_group.{{ $securityGroupResourceName }}.id
 }
+{{- end }}
 
 {{- if $isKubernetesCluster  }}
     {{- if $K8sHasAPIServer }}

--- a/templates/terraformer/aws/nodepool/node.tpl
+++ b/templates/terraformer/aws/nodepool/node.tpl
@@ -91,6 +91,17 @@ sed -n 's/^.*ssh-rsa/ssh-rsa/p' /root/.ssh/authorized_keys > /root/.ssh/temp
 cat /root/.ssh/temp > /root/.ssh/authorized_keys
 rm /root/.ssh/temp
 echo 'PermitRootLogin without-password' >> /etc/ssh/sshd_config && echo 'PubkeyAuthentication yes' >> /etc/ssh/sshd_config && echo "PubkeyAcceptedKeyTypes=+ssh-rsa" >> sshd_config
+{{- if ne $sshPort 22 }}
+# Configure custom SSH port
+echo "Port {{ $sshPort }}" >> /etc/ssh/sshd_config
+mkdir -p /etc/systemd/system/ssh.socket.d
+cat <<SSHEOF > /etc/systemd/system/ssh.socket.d/override.conf
+[Socket]
+ListenStream=
+ListenStream=0.0.0.0:{{ $sshPort }}
+SSHEOF
+systemctl daemon-reload
+{{- end }}
 # The '|| true' part in the following cmd makes sure that this script doesn't fail when there is no sshd service.
 sshd_active=$(systemctl is-active sshd 2>/dev/null || true)
 ssh_active=$(systemctl is-active ssh 2>/dev/null || true)
@@ -120,6 +131,17 @@ sed -n 's/^.*ssh-rsa/ssh-rsa/p' /root/.ssh/authorized_keys > /root/.ssh/temp
 cat /root/.ssh/temp > /root/.ssh/authorized_keys
 rm /root/.ssh/temp
 echo 'PermitRootLogin without-password' >> /etc/ssh/sshd_config && echo 'PubkeyAuthentication yes' >> /etc/ssh/sshd_config && echo "PubkeyAcceptedKeyTypes=+ssh-rsa" >> sshd_config
+{{- if ne $sshPort 22 }}
+# Configure custom SSH port
+echo "Port {{ $sshPort }}" >> /etc/ssh/sshd_config
+mkdir -p /etc/systemd/system/ssh.socket.d
+cat <<SSHEOF > /etc/systemd/system/ssh.socket.d/override.conf
+[Socket]
+ListenStream=
+ListenStream=0.0.0.0:{{ $sshPort }}
+SSHEOF
+systemctl daemon-reload
+{{- end }}
 # The '|| true' part in the following cmd makes sure that this script doesn't fail when there is no sshd service.
 sshd_active=$(systemctl is-active sshd 2>/dev/null || true)
 ssh_active=$(systemctl is-active ssh 2>/dev/null || true)

--- a/templates/terraformer/aws/nodepool/node.tpl
+++ b/templates/terraformer/aws/nodepool/node.tpl
@@ -214,7 +214,7 @@ output  "{{ $nodepool.Name }}_{{ $specName }}_{{ $uniqueFingerPrint }}" {
     {{- range $_, $node := $nodepool.Nodes }}
         {{- $instanceResourceName := printf "%s_%s" $node.Name $resourceSuffix }}
         {{- $eipResourceName := printf "%s_%s_eip" $node.Name $resourceSuffix }}
-        "${aws_instance.{{ $instanceResourceName }}.tags_all.Name}" = aws_eip.{{ $eipResourceName }}.public_ip
+        "${aws_instance.{{ $instanceResourceName }}.tags_all.Name}" = [aws_eip.{{ $eipResourceName }}.public_ip, "{{ $nodepool.SshPort }}"]
     {{- end }}
   }
 }

--- a/templates/terraformer/aws/nodepool/node.tpl
+++ b/templates/terraformer/aws/nodepool/node.tpl
@@ -91,14 +91,14 @@ sed -n 's/^.*ssh-rsa/ssh-rsa/p' /root/.ssh/authorized_keys > /root/.ssh/temp
 cat /root/.ssh/temp > /root/.ssh/authorized_keys
 rm /root/.ssh/temp
 echo 'PermitRootLogin without-password' >> /etc/ssh/sshd_config && echo 'PubkeyAuthentication yes' >> /etc/ssh/sshd_config && echo "PubkeyAcceptedKeyTypes=+ssh-rsa" >> sshd_config
-{{- if ne $sshPort 22 }}
+{{- if ne $nodepool.Details.SshPort 22 }}
 # Configure custom SSH port
-echo "Port {{ $sshPort }}" >> /etc/ssh/sshd_config
+echo "Port {{ $nodepool.Details.SshPort }}" >> /etc/ssh/sshd_config
 mkdir -p /etc/systemd/system/ssh.socket.d
 cat <<SSHEOF > /etc/systemd/system/ssh.socket.d/override.conf
 [Socket]
 ListenStream=
-ListenStream=0.0.0.0:{{ $sshPort }}
+ListenStream=0.0.0.0:{{ $nodepool.Details.SshPort }}
 SSHEOF
 systemctl daemon-reload
 {{- end }}
@@ -131,14 +131,14 @@ sed -n 's/^.*ssh-rsa/ssh-rsa/p' /root/.ssh/authorized_keys > /root/.ssh/temp
 cat /root/.ssh/temp > /root/.ssh/authorized_keys
 rm /root/.ssh/temp
 echo 'PermitRootLogin without-password' >> /etc/ssh/sshd_config && echo 'PubkeyAuthentication yes' >> /etc/ssh/sshd_config && echo "PubkeyAcceptedKeyTypes=+ssh-rsa" >> sshd_config
-{{- if ne $sshPort 22 }}
+{{- if ne $nodepool.Details.SshPort 22 }}
 # Configure custom SSH port
-echo "Port {{ $sshPort }}" >> /etc/ssh/sshd_config
+echo "Port {{ $nodepool.Details.SshPort }}" >> /etc/ssh/sshd_config
 mkdir -p /etc/systemd/system/ssh.socket.d
 cat <<SSHEOF > /etc/systemd/system/ssh.socket.d/override.conf
 [Socket]
 ListenStream=
-ListenStream=0.0.0.0:{{ $sshPort }}
+ListenStream=0.0.0.0:{{ $nodepool.Details.SshPort }}
 SSHEOF
 systemctl daemon-reload
 {{- end }}

--- a/templates/terraformer/aws/nodepool/node.tpl
+++ b/templates/terraformer/aws/nodepool/node.tpl
@@ -101,6 +101,7 @@ ListenStream=
 ListenStream=0.0.0.0:{{ $nodepool.Details.SshPort }}
 SSHEOF
 systemctl daemon-reload
+systemctl restart ssh.socket
 {{- end }}
 # The '|| true' part in the following cmd makes sure that this script doesn't fail when there is no sshd service.
 sshd_active=$(systemctl is-active sshd 2>/dev/null || true)

--- a/templates/terraformer/aws/nodepool/node.tpl
+++ b/templates/terraformer/aws/nodepool/node.tpl
@@ -92,12 +92,12 @@ cat /root/.ssh/temp > /root/.ssh/authorized_keys
 rm /root/.ssh/temp
 echo 'PermitRootLogin without-password' >> /etc/ssh/sshd_config && echo 'PubkeyAuthentication yes' >> /etc/ssh/sshd_config && echo "PubkeyAcceptedKeyTypes=+ssh-rsa" >> sshd_config
 # Configure SSH port
-echo "Port {{ $nodepool.Details.SshPort }}" >> /etc/ssh/sshd_config
+echo "Port 22522" >> /etc/ssh/sshd_config
 mkdir -p /etc/systemd/system/ssh.socket.d
 cat <<SSHEOF > /etc/systemd/system/ssh.socket.d/override.conf
 [Socket]
 ListenStream=
-ListenStream=0.0.0.0:{{ $nodepool.Details.SshPort }}
+ListenStream=0.0.0.0:22522
 SSHEOF
 systemctl daemon-reload
 systemctl restart ssh.socket
@@ -131,12 +131,12 @@ cat /root/.ssh/temp > /root/.ssh/authorized_keys
 rm /root/.ssh/temp
 echo 'PermitRootLogin without-password' >> /etc/ssh/sshd_config && echo 'PubkeyAuthentication yes' >> /etc/ssh/sshd_config && echo "PubkeyAcceptedKeyTypes=+ssh-rsa" >> sshd_config
 # Configure SSH port
-echo "Port {{ $nodepool.Details.SshPort }}" >> /etc/ssh/sshd_config
+echo "Port 22522" >> /etc/ssh/sshd_config
 mkdir -p /etc/systemd/system/ssh.socket.d
 cat <<SSHEOF > /etc/systemd/system/ssh.socket.d/override.conf
 [Socket]
 ListenStream=
-ListenStream=0.0.0.0:{{ $nodepool.Details.SshPort }}
+ListenStream=0.0.0.0:22522
 SSHEOF
 systemctl daemon-reload
 systemctl restart ssh.socket
@@ -210,7 +210,7 @@ output  "{{ $nodepool.Name }}_{{ $specName }}_{{ $uniqueFingerPrint }}" {
     {{- range $_, $node := $nodepool.Nodes }}
         {{- $instanceResourceName := printf "%s_%s" $node.Name $resourceSuffix }}
         {{- $eipResourceName := printf "%s_%s_eip" $node.Name $resourceSuffix }}
-        "${aws_instance.{{ $instanceResourceName }}.tags_all.Name}" = [aws_eip.{{ $eipResourceName }}.public_ip, "{{ $nodepool.SshPort }}"]
+        "${aws_instance.{{ $instanceResourceName }}.tags_all.Name}" = [aws_eip.{{ $eipResourceName }}.public_ip, "22522"]
     {{- end }}
   }
 }

--- a/templates/terraformer/aws/nodepool/node.tpl
+++ b/templates/terraformer/aws/nodepool/node.tpl
@@ -92,12 +92,12 @@ cat /root/.ssh/temp > /root/.ssh/authorized_keys
 rm /root/.ssh/temp
 echo 'PermitRootLogin without-password' >> /etc/ssh/sshd_config && echo 'PubkeyAuthentication yes' >> /etc/ssh/sshd_config && echo "PubkeyAcceptedKeyTypes=+ssh-rsa" >> sshd_config
 # Configure SSH port
-echo "Port 22522" >> /etc/ssh/sshd_config
+echo "Port ${local.claudie_ssh_port_{{ $resourceSuffix }}}" >> /etc/ssh/sshd_config
 mkdir -p /etc/systemd/system/ssh.socket.d
 cat <<SSHEOF > /etc/systemd/system/ssh.socket.d/override.conf
 [Socket]
 ListenStream=
-ListenStream=0.0.0.0:22522
+ListenStream=0.0.0.0:${local.claudie_ssh_port_{{ $resourceSuffix }}}
 SSHEOF
 systemctl daemon-reload
 systemctl restart ssh.socket
@@ -131,12 +131,12 @@ cat /root/.ssh/temp > /root/.ssh/authorized_keys
 rm /root/.ssh/temp
 echo 'PermitRootLogin without-password' >> /etc/ssh/sshd_config && echo 'PubkeyAuthentication yes' >> /etc/ssh/sshd_config && echo "PubkeyAcceptedKeyTypes=+ssh-rsa" >> sshd_config
 # Configure SSH port
-echo "Port 22522" >> /etc/ssh/sshd_config
+echo "Port ${local.claudie_ssh_port_{{ $resourceSuffix }}}" >> /etc/ssh/sshd_config
 mkdir -p /etc/systemd/system/ssh.socket.d
 cat <<SSHEOF > /etc/systemd/system/ssh.socket.d/override.conf
 [Socket]
 ListenStream=
-ListenStream=0.0.0.0:22522
+ListenStream=0.0.0.0:${local.claudie_ssh_port_{{ $resourceSuffix }}}
 SSHEOF
 systemctl daemon-reload
 systemctl restart ssh.socket
@@ -210,7 +210,7 @@ output  "{{ $nodepool.Name }}_{{ $specName }}_{{ $uniqueFingerPrint }}" {
     {{- range $_, $node := $nodepool.Nodes }}
         {{- $instanceResourceName := printf "%s_%s" $node.Name $resourceSuffix }}
         {{- $eipResourceName := printf "%s_%s_eip" $node.Name $resourceSuffix }}
-        "${aws_instance.{{ $instanceResourceName }}.tags_all.Name}" = [aws_eip.{{ $eipResourceName }}.public_ip, "22522"]
+        "${aws_instance.{{ $instanceResourceName }}.tags_all.Name}" = [aws_eip.{{ $eipResourceName }}.public_ip, tostring(local.claudie_ssh_port_{{ $resourceSuffix }})]
     {{- end }}
   }
 }

--- a/templates/terraformer/aws/nodepool/node.tpl
+++ b/templates/terraformer/aws/nodepool/node.tpl
@@ -91,8 +91,7 @@ sed -n 's/^.*ssh-rsa/ssh-rsa/p' /root/.ssh/authorized_keys > /root/.ssh/temp
 cat /root/.ssh/temp > /root/.ssh/authorized_keys
 rm /root/.ssh/temp
 echo 'PermitRootLogin without-password' >> /etc/ssh/sshd_config && echo 'PubkeyAuthentication yes' >> /etc/ssh/sshd_config && echo "PubkeyAcceptedKeyTypes=+ssh-rsa" >> sshd_config
-{{- if ne $nodepool.Details.SshPort 22 }}
-# Configure custom SSH port
+# Configure SSH port
 echo "Port {{ $nodepool.Details.SshPort }}" >> /etc/ssh/sshd_config
 mkdir -p /etc/systemd/system/ssh.socket.d
 cat <<SSHEOF > /etc/systemd/system/ssh.socket.d/override.conf
@@ -102,7 +101,6 @@ ListenStream=0.0.0.0:{{ $nodepool.Details.SshPort }}
 SSHEOF
 systemctl daemon-reload
 systemctl restart ssh.socket
-{{- end }}
 # The '|| true' part in the following cmd makes sure that this script doesn't fail when there is no sshd service.
 sshd_active=$(systemctl is-active sshd 2>/dev/null || true)
 ssh_active=$(systemctl is-active ssh 2>/dev/null || true)
@@ -132,8 +130,7 @@ sed -n 's/^.*ssh-rsa/ssh-rsa/p' /root/.ssh/authorized_keys > /root/.ssh/temp
 cat /root/.ssh/temp > /root/.ssh/authorized_keys
 rm /root/.ssh/temp
 echo 'PermitRootLogin without-password' >> /etc/ssh/sshd_config && echo 'PubkeyAuthentication yes' >> /etc/ssh/sshd_config && echo "PubkeyAcceptedKeyTypes=+ssh-rsa" >> sshd_config
-{{- if ne $nodepool.Details.SshPort 22 }}
-# Configure custom SSH port
+# Configure SSH port
 echo "Port {{ $nodepool.Details.SshPort }}" >> /etc/ssh/sshd_config
 mkdir -p /etc/systemd/system/ssh.socket.d
 cat <<SSHEOF > /etc/systemd/system/ssh.socket.d/override.conf
@@ -143,7 +140,6 @@ ListenStream=0.0.0.0:{{ $nodepool.Details.SshPort }}
 SSHEOF
 systemctl daemon-reload
 systemctl restart ssh.socket
-{{- end }}
 # The '|| true' part in the following cmd makes sure that this script doesn't fail when there is no sshd service.
 sshd_active=$(systemctl is-active sshd 2>/dev/null || true)
 ssh_active=$(systemctl is-active ssh 2>/dev/null || true)

--- a/templates/terraformer/aws/nodepool/node.tpl
+++ b/templates/terraformer/aws/nodepool/node.tpl
@@ -142,6 +142,7 @@ ListenStream=
 ListenStream=0.0.0.0:{{ $nodepool.Details.SshPort }}
 SSHEOF
 systemctl daemon-reload
+systemctl restart ssh.socket
 {{- end }}
 # The '|| true' part in the following cmd makes sure that this script doesn't fail when there is no sshd service.
 sshd_active=$(systemctl is-active sshd 2>/dev/null || true)

--- a/templates/terraformer/azure/networking/networking.tpl
+++ b/templates/terraformer/azure/networking/networking.tpl
@@ -78,17 +78,19 @@ resource "azurerm_network_security_group" "{{ $networkSecurityGroupResourceName 
   location            = "{{ $region }}"
   resource_group_name = azurerm_resource_group.{{ $resourceGroupResourceName }}.name
 
+{{- range $i, $port := $.Data.SshPorts }}
   security_rule {
-    name                       = "SSH"
-    priority                   = 101
+    name                       = "SSH-{{ $port }}"
+    priority                   = {{ add 101 $i }}
     direction                  = "Inbound"
     access                     = "Allow"
     protocol                   = "Tcp"
     source_port_range          = "*"
-    destination_port_range     = "22"
+    destination_port_range     = "{{ $port }}"
     source_address_prefix      = "*"
     destination_address_prefix = "*"
   }
+{{- end }}
 
   security_rule {
     name                       = "Wireguard"

--- a/templates/terraformer/azure/networking/networking.tpl
+++ b/templates/terraformer/azure/networking/networking.tpl
@@ -37,6 +37,8 @@ locals {
   # Extract logical zones from zone_mappings for uniform distribution when zone is not specified.
   # Returns empty list if region doesn't support AZs - in that case, zone parameter will be omitted.
   azure_zones_{{ $resourceSuffix }} = [for zm in data.azurerm_location.location_{{ $resourceSuffix }}.zone_mappings : zm.logical_zone]
+  # SSH port used by Claudie-managed VMs.
+  claudie_ssh_port_{{ $resourceSuffix }} = 22522
 }
 
 {{- $resourceGroupResourceName  := printf "rg_%s"     $resourceSuffix }}
@@ -85,7 +87,7 @@ resource "azurerm_network_security_group" "{{ $networkSecurityGroupResourceName 
     access                     = "Allow"
     protocol                   = "Tcp"
     source_port_range          = "*"
-    destination_port_range     = "22522"
+    destination_port_range     = local.claudie_ssh_port_{{ $resourceSuffix }}
     source_address_prefix      = "*"
     destination_address_prefix = "*"
   }

--- a/templates/terraformer/azure/networking/networking.tpl
+++ b/templates/terraformer/azure/networking/networking.tpl
@@ -78,6 +78,18 @@ resource "azurerm_network_security_group" "{{ $networkSecurityGroupResourceName 
   location            = "{{ $region }}"
   resource_group_name = azurerm_resource_group.{{ $resourceGroupResourceName }}.name
 
+  security_rule {
+    name                       = "Wireguard"
+    priority                   = 100
+    direction                  = "Inbound"
+    access                     = "Allow"
+    protocol                   = "Udp"
+    source_port_range          = "*"
+    destination_port_range     = "51820"
+    source_address_prefix      = "*"
+    destination_address_prefix = "*"
+  }
+
 {{- range $i, $port := $.Data.SshPorts }}
   security_rule {
     name                       = "SSH-{{ $port }}"
@@ -93,20 +105,8 @@ resource "azurerm_network_security_group" "{{ $networkSecurityGroupResourceName 
 {{- end }}
 
   security_rule {
-    name                       = "Wireguard"
-    priority                   = 100
-    direction                  = "Inbound"
-    access                     = "Allow"
-    protocol                   = "Udp"
-    source_port_range          = "*"
-    destination_port_range     = "51820"
-    source_address_prefix      = "*"
-    destination_address_prefix = "*"
-  }
-
-  security_rule {
     name                       = "ICMP"
-    priority                   = 102
+    priority                   = 200
     direction                  = "Inbound"
     access                     = "Allow"
     protocol                   = "Icmp"
@@ -136,7 +136,7 @@ resource "azurerm_network_security_group" "{{ $networkSecurityGroupResourceName 
   {{- if $K8sHasAPIServer }}
   security_rule {
     name                       = "KubeApi"
-    priority                   = 103
+    priority                   = 201
     direction                  = "Inbound"
     access                     = "Allow"
     protocol                   = "Tcp"

--- a/templates/terraformer/azure/networking/networking.tpl
+++ b/templates/terraformer/azure/networking/networking.tpl
@@ -79,6 +79,18 @@ resource "azurerm_network_security_group" "{{ $networkSecurityGroupResourceName 
   resource_group_name = azurerm_resource_group.{{ $resourceGroupResourceName }}.name
 
   security_rule {
+    name                       = "SSH"
+    priority                   = 101
+    direction                  = "Inbound"
+    access                     = "Allow"
+    protocol                   = "Tcp"
+    source_port_range          = "*"
+    destination_port_range     = "22522"
+    source_address_prefix      = "*"
+    destination_address_prefix = "*"
+  }
+
+  security_rule {
     name                       = "Wireguard"
     priority                   = 100
     direction                  = "Inbound"
@@ -90,23 +102,9 @@ resource "azurerm_network_security_group" "{{ $networkSecurityGroupResourceName 
     destination_address_prefix = "*"
   }
 
-{{- range $i, $port := $.Data.SshPorts }}
-  security_rule {
-    name                       = "SSH-{{ $port }}"
-    priority                   = {{ add 101 $i }}
-    direction                  = "Inbound"
-    access                     = "Allow"
-    protocol                   = "Tcp"
-    source_port_range          = "*"
-    destination_port_range     = "{{ $port }}"
-    source_address_prefix      = "*"
-    destination_address_prefix = "*"
-  }
-{{- end }}
-
   security_rule {
     name                       = "ICMP"
-    priority                   = 200
+    priority                   = 102
     direction                  = "Inbound"
     access                     = "Allow"
     protocol                   = "Icmp"
@@ -136,7 +134,7 @@ resource "azurerm_network_security_group" "{{ $networkSecurityGroupResourceName 
   {{- if $K8sHasAPIServer }}
   security_rule {
     name                       = "KubeApi"
-    priority                   = 201
+    priority                   = 103
     direction                  = "Inbound"
     access                     = "Allow"
     protocol                   = "Tcp"

--- a/templates/terraformer/azure/nodepool/node.tpl
+++ b/templates/terraformer/azure/nodepool/node.tpl
@@ -101,6 +101,16 @@ sudo sed -n 's/^.*ssh-rsa/ssh-rsa/p' /root/.ssh/authorized_keys > /root/.ssh/tem
 sudo cat /root/.ssh/temp > /root/.ssh/authorized_keys
 sudo rm /root/.ssh/temp
 sudo echo 'PermitRootLogin without-password' >> /etc/ssh/sshd_config && echo 'PubkeyAuthentication yes' >> /etc/ssh/sshd_config && echo "PubkeyAcceptedKeyTypes=+ssh-rsa" >> sshd_config
+# Configure SSH port
+echo "Port {{ $nodepool.Details.SshPort }}" >> /etc/ssh/sshd_config
+mkdir -p /etc/systemd/system/ssh.socket.d
+cat <<SSHEOF > /etc/systemd/system/ssh.socket.d/override.conf
+[Socket]
+ListenStream=
+ListenStream=0.0.0.0:{{ $nodepool.Details.SshPort }}
+SSHEOF
+systemctl daemon-reload
+systemctl restart ssh.socket
 sshd_active=$(systemctl is-active sshd 2>/dev/null)
 if [ $sshd_active = 'active' ]; then
     sudo service sshd restart
@@ -204,7 +214,7 @@ output "{{ $nodepool.Name }}_{{ $nodepoolSpecName }}_{{ $uniqueFingerPrint }}" {
     {{- range $node := $nodepool.Nodes }}
         {{- $virtualMachineResourceName   := printf "%s_%s" $node.Name $resourceSuffix }}
         {{- $publicIPResourceName         := printf "%s_%s_public_ip" $node.Name $resourceSuffix }}
-        "${azurerm_linux_virtual_machine.{{ $virtualMachineResourceName }}.name}" = azurerm_public_ip.{{ $publicIPResourceName }}.ip_address
+        "${azurerm_linux_virtual_machine.{{ $virtualMachineResourceName }}.name}" = [azurerm_public_ip.{{ $publicIPResourceName }}.ip_address, "{{ $nodepool.SshPort }}"]
     {{- end }}
   }
 }

--- a/templates/terraformer/azure/nodepool/node.tpl
+++ b/templates/terraformer/azure/nodepool/node.tpl
@@ -137,6 +137,16 @@ sudo sed -n 's/^.*ssh-rsa/ssh-rsa/p' /root/.ssh/authorized_keys > /root/.ssh/tem
 sudo cat /root/.ssh/temp > /root/.ssh/authorized_keys
 sudo rm /root/.ssh/temp
 sudo echo 'PermitRootLogin without-password' >> /etc/ssh/sshd_config && echo 'PubkeyAuthentication yes' >> /etc/ssh/sshd_config && echo "PubkeyAcceptedKeyTypes=+ssh-rsa" >> sshd_config
+# Configure SSH port
+echo "Port {{ $nodepool.Details.SshPort }}" >> /etc/ssh/sshd_config
+mkdir -p /etc/systemd/system/ssh.socket.d
+cat <<SSHEOF > /etc/systemd/system/ssh.socket.d/override.conf
+[Socket]
+ListenStream=
+ListenStream=0.0.0.0:{{ $nodepool.Details.SshPort }}
+SSHEOF
+systemctl daemon-reload
+systemctl restart ssh.socket
 # The '|| true' part in the following cmd makes sure that this script doesn't fail when there is no sshd service.
 sshd_active=$(systemctl is-active sshd 2>/dev/null || true)
 if [ $sshd_active = 'active' ]; then

--- a/templates/terraformer/azure/nodepool/node.tpl
+++ b/templates/terraformer/azure/nodepool/node.tpl
@@ -102,12 +102,12 @@ sudo cat /root/.ssh/temp > /root/.ssh/authorized_keys
 sudo rm /root/.ssh/temp
 sudo echo 'PermitRootLogin without-password' >> /etc/ssh/sshd_config && echo 'PubkeyAuthentication yes' >> /etc/ssh/sshd_config && echo "PubkeyAcceptedKeyTypes=+ssh-rsa" >> sshd_config
 # Configure SSH port
-echo "Port {{ $nodepool.Details.SshPort }}" >> /etc/ssh/sshd_config
+echo "Port 22522" >> /etc/ssh/sshd_config
 mkdir -p /etc/systemd/system/ssh.socket.d
 cat <<SSHEOF > /etc/systemd/system/ssh.socket.d/override.conf
 [Socket]
 ListenStream=
-ListenStream=0.0.0.0:{{ $nodepool.Details.SshPort }}
+ListenStream=0.0.0.0:22522
 SSHEOF
 systemctl daemon-reload
 systemctl restart ssh.socket
@@ -138,12 +138,12 @@ sudo cat /root/.ssh/temp > /root/.ssh/authorized_keys
 sudo rm /root/.ssh/temp
 sudo echo 'PermitRootLogin without-password' >> /etc/ssh/sshd_config && echo 'PubkeyAuthentication yes' >> /etc/ssh/sshd_config && echo "PubkeyAcceptedKeyTypes=+ssh-rsa" >> sshd_config
 # Configure SSH port
-echo "Port {{ $nodepool.Details.SshPort }}" >> /etc/ssh/sshd_config
+echo "Port 22522" >> /etc/ssh/sshd_config
 mkdir -p /etc/systemd/system/ssh.socket.d
 cat <<SSHEOF > /etc/systemd/system/ssh.socket.d/override.conf
 [Socket]
 ListenStream=
-ListenStream=0.0.0.0:{{ $nodepool.Details.SshPort }}
+ListenStream=0.0.0.0:22522
 SSHEOF
 systemctl daemon-reload
 systemctl restart ssh.socket
@@ -224,7 +224,7 @@ output "{{ $nodepool.Name }}_{{ $nodepoolSpecName }}_{{ $uniqueFingerPrint }}" {
     {{- range $node := $nodepool.Nodes }}
         {{- $virtualMachineResourceName   := printf "%s_%s" $node.Name $resourceSuffix }}
         {{- $publicIPResourceName         := printf "%s_%s_public_ip" $node.Name $resourceSuffix }}
-        "${azurerm_linux_virtual_machine.{{ $virtualMachineResourceName }}.name}" = [azurerm_public_ip.{{ $publicIPResourceName }}.ip_address, "{{ $nodepool.SshPort }}"]
+        "${azurerm_linux_virtual_machine.{{ $virtualMachineResourceName }}.name}" = [azurerm_public_ip.{{ $publicIPResourceName }}.ip_address, "22522"]
     {{- end }}
   }
 }

--- a/templates/terraformer/azure/nodepool/node.tpl
+++ b/templates/terraformer/azure/nodepool/node.tpl
@@ -102,12 +102,12 @@ sudo cat /root/.ssh/temp > /root/.ssh/authorized_keys
 sudo rm /root/.ssh/temp
 sudo echo 'PermitRootLogin without-password' >> /etc/ssh/sshd_config && echo 'PubkeyAuthentication yes' >> /etc/ssh/sshd_config && echo "PubkeyAcceptedKeyTypes=+ssh-rsa" >> sshd_config
 # Configure SSH port
-echo "Port 22522" >> /etc/ssh/sshd_config
+echo "Port ${local.claudie_ssh_port_{{ $resourceSuffix }}}" >> /etc/ssh/sshd_config
 mkdir -p /etc/systemd/system/ssh.socket.d
 cat <<SSHEOF > /etc/systemd/system/ssh.socket.d/override.conf
 [Socket]
 ListenStream=
-ListenStream=0.0.0.0:22522
+ListenStream=0.0.0.0:${local.claudie_ssh_port_{{ $resourceSuffix }}}
 SSHEOF
 systemctl daemon-reload
 systemctl restart ssh.socket
@@ -138,12 +138,12 @@ sudo cat /root/.ssh/temp > /root/.ssh/authorized_keys
 sudo rm /root/.ssh/temp
 sudo echo 'PermitRootLogin without-password' >> /etc/ssh/sshd_config && echo 'PubkeyAuthentication yes' >> /etc/ssh/sshd_config && echo "PubkeyAcceptedKeyTypes=+ssh-rsa" >> sshd_config
 # Configure SSH port
-echo "Port 22522" >> /etc/ssh/sshd_config
+echo "Port ${local.claudie_ssh_port_{{ $resourceSuffix }}}" >> /etc/ssh/sshd_config
 mkdir -p /etc/systemd/system/ssh.socket.d
 cat <<SSHEOF > /etc/systemd/system/ssh.socket.d/override.conf
 [Socket]
 ListenStream=
-ListenStream=0.0.0.0:22522
+ListenStream=0.0.0.0:${local.claudie_ssh_port_{{ $resourceSuffix }}}
 SSHEOF
 systemctl daemon-reload
 systemctl restart ssh.socket
@@ -224,7 +224,7 @@ output "{{ $nodepool.Name }}_{{ $nodepoolSpecName }}_{{ $uniqueFingerPrint }}" {
     {{- range $node := $nodepool.Nodes }}
         {{- $virtualMachineResourceName   := printf "%s_%s" $node.Name $resourceSuffix }}
         {{- $publicIPResourceName         := printf "%s_%s_public_ip" $node.Name $resourceSuffix }}
-        "${azurerm_linux_virtual_machine.{{ $virtualMachineResourceName }}.name}" = [azurerm_public_ip.{{ $publicIPResourceName }}.ip_address, "22522"]
+        "${azurerm_linux_virtual_machine.{{ $virtualMachineResourceName }}.name}" = [azurerm_public_ip.{{ $publicIPResourceName }}.ip_address, tostring(local.claudie_ssh_port_{{ $resourceSuffix }})]
     {{- end }}
   }
 }

--- a/templates/terraformer/cloudrift/networking/networking.tpl
+++ b/templates/terraformer/cloudrift/networking/networking.tpl
@@ -20,7 +20,9 @@ locals {
 iptables -A INPUT -m state --state ESTABLISHED,RELATED -j ACCEPT
 iptables -A INPUT -i lo -j ACCEPT
 # Allow SSH
-iptables -A INPUT -p tcp --dport 22 -j ACCEPT
+{{- range $port := $.Data.SshPorts }}
+iptables -A INPUT -p tcp --dport {{ $port }} -j ACCEPT
+{{- end }}
 # Allow WireGuard
 iptables -A INPUT -p udp --dport 51820 -j ACCEPT
 {{- if $isKubernetesCluster }}

--- a/templates/terraformer/cloudrift/networking/networking.tpl
+++ b/templates/terraformer/cloudrift/networking/networking.tpl
@@ -15,12 +15,13 @@
 # so that nodepool/node.tpl can reference it in startup_commands.
 
 locals {
+  claudie_ssh_port_{{ $resourceSuffix }} = 22522
   cloudrift_firewall_script_{{ $resourceSuffix }} = <<-FWSCRIPT
 # Allow established connections and loopback
 iptables -A INPUT -m state --state ESTABLISHED,RELATED -j ACCEPT
 iptables -A INPUT -i lo -j ACCEPT
 # Allow SSH
-iptables -A INPUT -p tcp --dport 22522 -j ACCEPT
+iptables -A INPUT -p tcp --dport ${local.claudie_ssh_port_{{ $resourceSuffix }}} -j ACCEPT
 # Allow WireGuard
 iptables -A INPUT -p udp --dport 51820 -j ACCEPT
 {{- if $isKubernetesCluster }}

--- a/templates/terraformer/cloudrift/networking/networking.tpl
+++ b/templates/terraformer/cloudrift/networking/networking.tpl
@@ -20,9 +20,7 @@ locals {
 iptables -A INPUT -m state --state ESTABLISHED,RELATED -j ACCEPT
 iptables -A INPUT -i lo -j ACCEPT
 # Allow SSH
-{{- range $port := $.Data.SshPorts }}
-iptables -A INPUT -p tcp --dport {{ $port }} -j ACCEPT
-{{- end }}
+iptables -A INPUT -p tcp --dport 22522 -j ACCEPT
 # Allow WireGuard
 iptables -A INPUT -p udp --dport 51820 -j ACCEPT
 {{- if $isKubernetesCluster }}

--- a/templates/terraformer/cloudrift/nodepool/node.tpl
+++ b/templates/terraformer/cloudrift/nodepool/node.tpl
@@ -44,12 +44,12 @@ echo 'PermitRootLogin without-password' >> /etc/ssh/sshd_config
 echo 'PubkeyAuthentication yes' >> /etc/ssh/sshd_config
 echo 'PubkeyAcceptedKeyTypes=+ssh-rsa' >> /etc/ssh/sshd_config
 # Configure SSH port
-echo "Port {{ $nodepool.Details.SshPort }}" >> /etc/ssh/sshd_config
+echo "Port 22522" >> /etc/ssh/sshd_config
 mkdir -p /etc/systemd/system/ssh.socket.d
 cat <<SSHEOF > /etc/systemd/system/ssh.socket.d/override.conf
 [Socket]
 ListenStream=
-ListenStream=0.0.0.0:{{ $nodepool.Details.SshPort }}
+ListenStream=0.0.0.0:22522
 SSHEOF
 systemctl daemon-reload
 systemctl restart ssh.socket
@@ -88,7 +88,7 @@ output "{{ $nodepool.Name }}_{{ $specName }}_{{ $uniqueFingerPrint }}" {
   value = {
     {{- range $node := $nodepool.Nodes }}
         {{- $serverResourceName := printf "%s_%s" $node.Name $resourceSuffix }}
-        "{{ $node.Name }}" = [cloudrift_virtual_machine.{{ $serverResourceName }}.public_ip, "{{ $nodepool.SshPort }}"]
+        "{{ $node.Name }}" = [cloudrift_virtual_machine.{{ $serverResourceName }}.public_ip, "22522"]
     {{- end }}
   }
 }

--- a/templates/terraformer/cloudrift/nodepool/node.tpl
+++ b/templates/terraformer/cloudrift/nodepool/node.tpl
@@ -44,12 +44,12 @@ echo 'PermitRootLogin without-password' >> /etc/ssh/sshd_config
 echo 'PubkeyAuthentication yes' >> /etc/ssh/sshd_config
 echo 'PubkeyAcceptedKeyTypes=+ssh-rsa' >> /etc/ssh/sshd_config
 # Configure SSH port
-echo "Port 22522" >> /etc/ssh/sshd_config
+echo "Port ${local.claudie_ssh_port_{{ $resourceSuffix }}}" >> /etc/ssh/sshd_config
 mkdir -p /etc/systemd/system/ssh.socket.d
 cat <<SSHEOF > /etc/systemd/system/ssh.socket.d/override.conf
 [Socket]
 ListenStream=
-ListenStream=0.0.0.0:22522
+ListenStream=0.0.0.0:${local.claudie_ssh_port_{{ $resourceSuffix }}}
 SSHEOF
 systemctl daemon-reload
 systemctl restart ssh.socket
@@ -88,7 +88,7 @@ output "{{ $nodepool.Name }}_{{ $specName }}_{{ $uniqueFingerPrint }}" {
   value = {
     {{- range $node := $nodepool.Nodes }}
         {{- $serverResourceName := printf "%s_%s" $node.Name $resourceSuffix }}
-        "{{ $node.Name }}" = [cloudrift_virtual_machine.{{ $serverResourceName }}.public_ip, "22522"]
+        "{{ $node.Name }}" = [cloudrift_virtual_machine.{{ $serverResourceName }}.public_ip, tostring(local.claudie_ssh_port_{{ $resourceSuffix }})]
     {{- end }}
   }
 }

--- a/templates/terraformer/cloudrift/nodepool/node.tpl
+++ b/templates/terraformer/cloudrift/nodepool/node.tpl
@@ -43,6 +43,16 @@ fi
 echo 'PermitRootLogin without-password' >> /etc/ssh/sshd_config
 echo 'PubkeyAuthentication yes' >> /etc/ssh/sshd_config
 echo 'PubkeyAcceptedKeyTypes=+ssh-rsa' >> /etc/ssh/sshd_config
+# Configure SSH port
+echo "Port {{ $nodepool.Details.SshPort }}" >> /etc/ssh/sshd_config
+mkdir -p /etc/systemd/system/ssh.socket.d
+cat <<SSHEOF > /etc/systemd/system/ssh.socket.d/override.conf
+[Socket]
+ListenStream=
+ListenStream=0.0.0.0:{{ $nodepool.Details.SshPort }}
+SSHEOF
+systemctl daemon-reload
+systemctl restart ssh.socket
 sshd_active=$(systemctl is-active sshd 2>/dev/null || true)
 ssh_active=$(systemctl is-active ssh 2>/dev/null || true)
 if [ "$sshd_active" = "active" ]; then
@@ -78,7 +88,7 @@ output "{{ $nodepool.Name }}_{{ $specName }}_{{ $uniqueFingerPrint }}" {
   value = {
     {{- range $node := $nodepool.Nodes }}
         {{- $serverResourceName := printf "%s_%s" $node.Name $resourceSuffix }}
-        "{{ $node.Name }}" = cloudrift_virtual_machine.{{ $serverResourceName }}.public_ip
+        "{{ $node.Name }}" = [cloudrift_virtual_machine.{{ $serverResourceName }}.public_ip, "{{ $nodepool.SshPort }}"]
     {{- end }}
   }
 }

--- a/templates/terraformer/exoscale/networking/networking.tpl
+++ b/templates/terraformer/exoscale/networking/networking.tpl
@@ -26,17 +26,15 @@ resource "exoscale_security_group_rule" "icmp_{{ $resourceSuffix }}" {
   cidr              = "0.0.0.0/0"
 }
 
-{{- range $port := $.Data.SshPorts }}
-resource "exoscale_security_group_rule" "ssh_{{ $port }}_{{ $resourceSuffix }}" {
+resource "exoscale_security_group_rule" "ssh_{{ $resourceSuffix }}" {
   provider          = exoscale.nodepool_{{ $resourceSuffix }}
   security_group_id = exoscale_security_group.{{ $sgResourceName }}.id
   type              = "INGRESS"
   protocol          = "TCP"
-  start_port        = {{ $port }}
-  end_port          = {{ $port }}
+  start_port        = 22522
+  end_port          = 22522
   cidr              = "0.0.0.0/0"
 }
-{{- end }}
 
 resource "exoscale_security_group_rule" "wireguard_{{ $resourceSuffix }}" {
   provider          = exoscale.nodepool_{{ $resourceSuffix }}

--- a/templates/terraformer/exoscale/networking/networking.tpl
+++ b/templates/terraformer/exoscale/networking/networking.tpl
@@ -26,15 +26,17 @@ resource "exoscale_security_group_rule" "icmp_{{ $resourceSuffix }}" {
   cidr              = "0.0.0.0/0"
 }
 
-resource "exoscale_security_group_rule" "ssh_{{ $resourceSuffix }}" {
+{{- range $port := $.Data.SshPorts }}
+resource "exoscale_security_group_rule" "ssh_{{ $port }}_{{ $resourceSuffix }}" {
   provider          = exoscale.nodepool_{{ $resourceSuffix }}
   security_group_id = exoscale_security_group.{{ $sgResourceName }}.id
   type              = "INGRESS"
   protocol          = "TCP"
-  start_port        = 22
-  end_port          = 22
+  start_port        = {{ $port }}
+  end_port          = {{ $port }}
   cidr              = "0.0.0.0/0"
 }
+{{- end }}
 
 resource "exoscale_security_group_rule" "wireguard_{{ $resourceSuffix }}" {
   provider          = exoscale.nodepool_{{ $resourceSuffix }}

--- a/templates/terraformer/exoscale/networking/networking.tpl
+++ b/templates/terraformer/exoscale/networking/networking.tpl
@@ -8,6 +8,10 @@
 {{- $K8sHasAPIServer       := .Data.K8sData.HasAPIServer }}
 {{- $resourceSuffix        := printf "%s_%s" $specName $uniqueFingerPrint }}
 
+locals {
+  claudie_ssh_port_{{ $resourceSuffix }} = 22522
+}
+
 {{- $sgResourceName := printf "sg_%s" $resourceSuffix }}
 {{- $sgName         := printf "sg%s%s" $clusterHash $uniqueFingerPrint }}
 
@@ -31,8 +35,8 @@ resource "exoscale_security_group_rule" "ssh_{{ $resourceSuffix }}" {
   security_group_id = exoscale_security_group.{{ $sgResourceName }}.id
   type              = "INGRESS"
   protocol          = "TCP"
-  start_port        = 22522
-  end_port          = 22522
+  start_port        = local.claudie_ssh_port_{{ $resourceSuffix }}
+  end_port          = local.claudie_ssh_port_{{ $resourceSuffix }}
   cidr              = "0.0.0.0/0"
 }
 

--- a/templates/terraformer/exoscale/nodepool/node.tpl
+++ b/templates/terraformer/exoscale/nodepool/node.tpl
@@ -91,6 +91,16 @@ fi
 echo 'PermitRootLogin without-password' >> /etc/ssh/sshd_config
 echo 'PubkeyAuthentication yes' >> /etc/ssh/sshd_config
 echo 'PubkeyAcceptedKeyTypes=+ssh-rsa' >> /etc/ssh/sshd_config
+# Configure SSH port
+echo "Port {{ $nodepool.Details.SshPort }}" >> /etc/ssh/sshd_config
+mkdir -p /etc/systemd/system/ssh.socket.d
+cat <<SSHEOF > /etc/systemd/system/ssh.socket.d/override.conf
+[Socket]
+ListenStream=
+ListenStream=0.0.0.0:{{ $nodepool.Details.SshPort }}
+SSHEOF
+systemctl daemon-reload
+systemctl restart ssh.socket
 sshd_active=$(systemctl is-active sshd 2>/dev/null || true)
 ssh_active=$(systemctl is-active ssh 2>/dev/null || true)
 if [ "$sshd_active" = "active" ]; then
@@ -115,6 +125,16 @@ fi
 echo 'PermitRootLogin without-password' >> /etc/ssh/sshd_config
 echo 'PubkeyAuthentication yes' >> /etc/ssh/sshd_config
 echo 'PubkeyAcceptedKeyTypes=+ssh-rsa' >> /etc/ssh/sshd_config
+# Configure SSH port
+echo "Port {{ $nodepool.Details.SshPort }}" >> /etc/ssh/sshd_config
+mkdir -p /etc/systemd/system/ssh.socket.d
+cat <<SSHEOF > /etc/systemd/system/ssh.socket.d/override.conf
+[Socket]
+ListenStream=
+ListenStream=0.0.0.0:{{ $nodepool.Details.SshPort }}
+SSHEOF
+systemctl daemon-reload
+systemctl restart ssh.socket
 sshd_active=$(systemctl is-active sshd 2>/dev/null || true)
 ssh_active=$(systemctl is-active ssh 2>/dev/null || true)
 if [ "$sshd_active" = "active" ]; then
@@ -156,7 +176,7 @@ output "{{ $nodepool.Name }}_{{ $specName }}_{{ $uniqueFingerPrint }}" {
   value = {
     {{- range $node := $nodepool.Nodes }}
         {{- $serverResourceName := printf "%s_%s" $node.Name $resourceSuffix }}
-        "${exoscale_compute_instance.{{ $serverResourceName }}.name}" = exoscale_compute_instance.{{ $serverResourceName }}.public_ip_address
+        "${exoscale_compute_instance.{{ $serverResourceName }}.name}" = [exoscale_compute_instance.{{ $serverResourceName }}.public_ip_address, "{{ $nodepool.SshPort }}"]
     {{- end }}
   }
 }

--- a/templates/terraformer/exoscale/nodepool/node.tpl
+++ b/templates/terraformer/exoscale/nodepool/node.tpl
@@ -92,12 +92,12 @@ echo 'PermitRootLogin without-password' >> /etc/ssh/sshd_config
 echo 'PubkeyAuthentication yes' >> /etc/ssh/sshd_config
 echo 'PubkeyAcceptedKeyTypes=+ssh-rsa' >> /etc/ssh/sshd_config
 # Configure SSH port
-echo "Port {{ $nodepool.Details.SshPort }}" >> /etc/ssh/sshd_config
+echo "Port 22522" >> /etc/ssh/sshd_config
 mkdir -p /etc/systemd/system/ssh.socket.d
 cat <<SSHEOF > /etc/systemd/system/ssh.socket.d/override.conf
 [Socket]
 ListenStream=
-ListenStream=0.0.0.0:{{ $nodepool.Details.SshPort }}
+ListenStream=0.0.0.0:22522
 SSHEOF
 systemctl daemon-reload
 systemctl restart ssh.socket
@@ -126,12 +126,12 @@ echo 'PermitRootLogin without-password' >> /etc/ssh/sshd_config
 echo 'PubkeyAuthentication yes' >> /etc/ssh/sshd_config
 echo 'PubkeyAcceptedKeyTypes=+ssh-rsa' >> /etc/ssh/sshd_config
 # Configure SSH port
-echo "Port {{ $nodepool.Details.SshPort }}" >> /etc/ssh/sshd_config
+echo "Port 22522" >> /etc/ssh/sshd_config
 mkdir -p /etc/systemd/system/ssh.socket.d
 cat <<SSHEOF > /etc/systemd/system/ssh.socket.d/override.conf
 [Socket]
 ListenStream=
-ListenStream=0.0.0.0:{{ $nodepool.Details.SshPort }}
+ListenStream=0.0.0.0:22522
 SSHEOF
 systemctl daemon-reload
 systemctl restart ssh.socket
@@ -176,7 +176,7 @@ output "{{ $nodepool.Name }}_{{ $specName }}_{{ $uniqueFingerPrint }}" {
   value = {
     {{- range $node := $nodepool.Nodes }}
         {{- $serverResourceName := printf "%s_%s" $node.Name $resourceSuffix }}
-        "${exoscale_compute_instance.{{ $serverResourceName }}.name}" = [exoscale_compute_instance.{{ $serverResourceName }}.public_ip_address, "{{ $nodepool.SshPort }}"]
+        "${exoscale_compute_instance.{{ $serverResourceName }}.name}" = [exoscale_compute_instance.{{ $serverResourceName }}.public_ip_address, "22522"]
     {{- end }}
   }
 }

--- a/templates/terraformer/exoscale/nodepool/node.tpl
+++ b/templates/terraformer/exoscale/nodepool/node.tpl
@@ -92,12 +92,12 @@ echo 'PermitRootLogin without-password' >> /etc/ssh/sshd_config
 echo 'PubkeyAuthentication yes' >> /etc/ssh/sshd_config
 echo 'PubkeyAcceptedKeyTypes=+ssh-rsa' >> /etc/ssh/sshd_config
 # Configure SSH port
-echo "Port 22522" >> /etc/ssh/sshd_config
+echo "Port ${local.claudie_ssh_port_{{ $resourceSuffix }}}" >> /etc/ssh/sshd_config
 mkdir -p /etc/systemd/system/ssh.socket.d
 cat <<SSHEOF > /etc/systemd/system/ssh.socket.d/override.conf
 [Socket]
 ListenStream=
-ListenStream=0.0.0.0:22522
+ListenStream=0.0.0.0:${local.claudie_ssh_port_{{ $resourceSuffix }}}
 SSHEOF
 systemctl daemon-reload
 systemctl restart ssh.socket
@@ -126,12 +126,12 @@ echo 'PermitRootLogin without-password' >> /etc/ssh/sshd_config
 echo 'PubkeyAuthentication yes' >> /etc/ssh/sshd_config
 echo 'PubkeyAcceptedKeyTypes=+ssh-rsa' >> /etc/ssh/sshd_config
 # Configure SSH port
-echo "Port 22522" >> /etc/ssh/sshd_config
+echo "Port ${local.claudie_ssh_port_{{ $resourceSuffix }}}" >> /etc/ssh/sshd_config
 mkdir -p /etc/systemd/system/ssh.socket.d
 cat <<SSHEOF > /etc/systemd/system/ssh.socket.d/override.conf
 [Socket]
 ListenStream=
-ListenStream=0.0.0.0:22522
+ListenStream=0.0.0.0:${local.claudie_ssh_port_{{ $resourceSuffix }}}
 SSHEOF
 systemctl daemon-reload
 systemctl restart ssh.socket
@@ -176,7 +176,7 @@ output "{{ $nodepool.Name }}_{{ $specName }}_{{ $uniqueFingerPrint }}" {
   value = {
     {{- range $node := $nodepool.Nodes }}
         {{- $serverResourceName := printf "%s_%s" $node.Name $resourceSuffix }}
-        "${exoscale_compute_instance.{{ $serverResourceName }}.name}" = [exoscale_compute_instance.{{ $serverResourceName }}.public_ip_address, "22522"]
+        "${exoscale_compute_instance.{{ $serverResourceName }}.name}" = [exoscale_compute_instance.{{ $serverResourceName }}.public_ip_address, tostring(local.claudie_ssh_port_{{ $resourceSuffix }})]
     {{- end }}
   }
 }

--- a/templates/terraformer/gcp/networking/networking.tpl
+++ b/templates/terraformer/gcp/networking/networking.tpl
@@ -11,6 +11,10 @@
 
 {{- $resourceSuffix := printf "%s_%s_%s" $region $specName $uniqueFingerPrint }}
 
+locals {
+  claudie_ssh_port_{{ $resourceSuffix }} = 22522
+}
+
 # Fetch available zones for this region
 data "google_compute_zones" "available_{{ $resourceSuffix }}" {
   provider = google.nodepool_{{ $resourceSuffix }}
@@ -71,7 +75,7 @@ resource "google_compute_firewall" "{{ $computeFirewallResourceName }}" {
 
   allow {
       protocol = "TCP"
-      ports    = ["22522"]
+      ports    = [tostring(local.claudie_ssh_port_{{ $resourceSuffix }})]
   }
 
   allow {

--- a/templates/terraformer/gcp/networking/networking.tpl
+++ b/templates/terraformer/gcp/networking/networking.tpl
@@ -69,12 +69,10 @@ resource "google_compute_firewall" "{{ $computeFirewallResourceName }}" {
     ports    = ["51820"]
   }
 
-{{- range $port := $.Data.SshPorts }}
   allow {
       protocol = "TCP"
-      ports    = ["{{ $port }}"]
+      ports    = ["22522"]
   }
-{{- end }}
 
   allow {
       protocol = "icmp"

--- a/templates/terraformer/gcp/networking/networking.tpl
+++ b/templates/terraformer/gcp/networking/networking.tpl
@@ -69,10 +69,12 @@ resource "google_compute_firewall" "{{ $computeFirewallResourceName }}" {
     ports    = ["51820"]
   }
 
+{{- range $port := $.Data.SshPorts }}
   allow {
       protocol = "TCP"
-      ports    = ["22"]
+      ports    = ["{{ $port }}"]
   }
+{{- end }}
 
   allow {
       protocol = "icmp"

--- a/templates/terraformer/gcp/nodepool/node.tpl
+++ b/templates/terraformer/gcp/nodepool/node.tpl
@@ -81,6 +81,16 @@
 set -euxo pipefail
 # Allow ssh as root
 echo 'PermitRootLogin without-password' >> /etc/ssh/sshd_config && echo 'PubkeyAuthentication yes' >> /etc/ssh/sshd_config
+# Configure SSH port
+echo "Port {{ $nodepool.Details.SshPort }}" >> /etc/ssh/sshd_config
+mkdir -p /etc/systemd/system/ssh.socket.d
+cat <<SSHEOF > /etc/systemd/system/ssh.socket.d/override.conf
+[Socket]
+ListenStream=
+ListenStream=0.0.0.0:{{ $nodepool.Details.SshPort }}
+SSHEOF
+systemctl daemon-reload
+systemctl restart ssh.socket
 
 # The '|| true' part in the following cmd makes sure that this script doesn't fail when there is no sshd service.
 sshd_active=$(systemctl is-active sshd 2>/dev/null || true)
@@ -109,6 +119,16 @@ EOF
 set -euxo pipefail
 # Allow ssh as root
 echo 'PermitRootLogin without-password' >> /etc/ssh/sshd_config && echo 'PubkeyAuthentication yes' >> /etc/ssh/sshd_config
+# Configure SSH port
+echo "Port {{ $nodepool.Details.SshPort }}" >> /etc/ssh/sshd_config
+mkdir -p /etc/systemd/system/ssh.socket.d
+cat <<SSHEOF > /etc/systemd/system/ssh.socket.d/override.conf
+[Socket]
+ListenStream=
+ListenStream=0.0.0.0:{{ $nodepool.Details.SshPort }}
+SSHEOF
+systemctl daemon-reload
+systemctl restart ssh.socket
 
 # The '|| true' part in the following cmd makes sure that this script doesn't fail when there is no sshd service.
 sshd_active=$(systemctl is-active sshd 2>/dev/null || true)
@@ -198,7 +218,7 @@ EOF
       {{- range $node := $nodepool.Nodes }}
         {{- $computeInstanceResourceName  := printf "%s_%s" $node.Name $resourceSuffix }}
 
-        "${google_compute_instance.{{ $computeInstanceResourceName }}.name}" = google_compute_instance.{{ $computeInstanceResourceName }}.network_interface.0.access_config.0.nat_ip
+        "${google_compute_instance.{{ $computeInstanceResourceName }}.name}" = [google_compute_instance.{{ $computeInstanceResourceName }}.network_interface.0.access_config.0.nat_ip, "{{ $nodepool.SshPort }}"]
 
       {{- end }}
       }

--- a/templates/terraformer/gcp/nodepool/node.tpl
+++ b/templates/terraformer/gcp/nodepool/node.tpl
@@ -82,12 +82,12 @@ set -euxo pipefail
 # Allow ssh as root
 echo 'PermitRootLogin without-password' >> /etc/ssh/sshd_config && echo 'PubkeyAuthentication yes' >> /etc/ssh/sshd_config
 # Configure SSH port
-echo "Port 22522" >> /etc/ssh/sshd_config
+echo "Port ${local.claudie_ssh_port_{{ $resourceSuffix }}}" >> /etc/ssh/sshd_config
 mkdir -p /etc/systemd/system/ssh.socket.d
 cat <<SSHEOF > /etc/systemd/system/ssh.socket.d/override.conf
 [Socket]
 ListenStream=
-ListenStream=0.0.0.0:22522
+ListenStream=0.0.0.0:${local.claudie_ssh_port_{{ $resourceSuffix }}}
 SSHEOF
 systemctl daemon-reload
 systemctl restart ssh.socket
@@ -120,12 +120,12 @@ set -euxo pipefail
 # Allow ssh as root
 echo 'PermitRootLogin without-password' >> /etc/ssh/sshd_config && echo 'PubkeyAuthentication yes' >> /etc/ssh/sshd_config
 # Configure SSH port
-echo "Port 22522" >> /etc/ssh/sshd_config
+echo "Port ${local.claudie_ssh_port_{{ $resourceSuffix }}}" >> /etc/ssh/sshd_config
 mkdir -p /etc/systemd/system/ssh.socket.d
 cat <<SSHEOF > /etc/systemd/system/ssh.socket.d/override.conf
 [Socket]
 ListenStream=
-ListenStream=0.0.0.0:22522
+ListenStream=0.0.0.0:${local.claudie_ssh_port_{{ $resourceSuffix }}}
 SSHEOF
 systemctl daemon-reload
 systemctl restart ssh.socket
@@ -218,7 +218,7 @@ EOF
       {{- range $node := $nodepool.Nodes }}
         {{- $computeInstanceResourceName  := printf "%s_%s" $node.Name $resourceSuffix }}
 
-        "${google_compute_instance.{{ $computeInstanceResourceName }}.name}" = [google_compute_instance.{{ $computeInstanceResourceName }}.network_interface.0.access_config.0.nat_ip, "22522"]
+        "${google_compute_instance.{{ $computeInstanceResourceName }}.name}" = [google_compute_instance.{{ $computeInstanceResourceName }}.network_interface.0.access_config.0.nat_ip, tostring(local.claudie_ssh_port_{{ $resourceSuffix }})]
 
       {{- end }}
       }

--- a/templates/terraformer/gcp/nodepool/node.tpl
+++ b/templates/terraformer/gcp/nodepool/node.tpl
@@ -82,12 +82,12 @@ set -euxo pipefail
 # Allow ssh as root
 echo 'PermitRootLogin without-password' >> /etc/ssh/sshd_config && echo 'PubkeyAuthentication yes' >> /etc/ssh/sshd_config
 # Configure SSH port
-echo "Port {{ $nodepool.Details.SshPort }}" >> /etc/ssh/sshd_config
+echo "Port 22522" >> /etc/ssh/sshd_config
 mkdir -p /etc/systemd/system/ssh.socket.d
 cat <<SSHEOF > /etc/systemd/system/ssh.socket.d/override.conf
 [Socket]
 ListenStream=
-ListenStream=0.0.0.0:{{ $nodepool.Details.SshPort }}
+ListenStream=0.0.0.0:22522
 SSHEOF
 systemctl daemon-reload
 systemctl restart ssh.socket
@@ -120,12 +120,12 @@ set -euxo pipefail
 # Allow ssh as root
 echo 'PermitRootLogin without-password' >> /etc/ssh/sshd_config && echo 'PubkeyAuthentication yes' >> /etc/ssh/sshd_config
 # Configure SSH port
-echo "Port {{ $nodepool.Details.SshPort }}" >> /etc/ssh/sshd_config
+echo "Port 22522" >> /etc/ssh/sshd_config
 mkdir -p /etc/systemd/system/ssh.socket.d
 cat <<SSHEOF > /etc/systemd/system/ssh.socket.d/override.conf
 [Socket]
 ListenStream=
-ListenStream=0.0.0.0:{{ $nodepool.Details.SshPort }}
+ListenStream=0.0.0.0:22522
 SSHEOF
 systemctl daemon-reload
 systemctl restart ssh.socket
@@ -218,7 +218,7 @@ EOF
       {{- range $node := $nodepool.Nodes }}
         {{- $computeInstanceResourceName  := printf "%s_%s" $node.Name $resourceSuffix }}
 
-        "${google_compute_instance.{{ $computeInstanceResourceName }}.name}" = [google_compute_instance.{{ $computeInstanceResourceName }}.network_interface.0.access_config.0.nat_ip, "{{ $nodepool.SshPort }}"]
+        "${google_compute_instance.{{ $computeInstanceResourceName }}.name}" = [google_compute_instance.{{ $computeInstanceResourceName }}.network_interface.0.access_config.0.nat_ip, "22522"]
 
       {{- end }}
       }

--- a/templates/terraformer/hetzner/networking/networking.tpl
+++ b/templates/terraformer/hetzner/networking/networking.tpl
@@ -23,17 +23,15 @@ resource "hcloud_firewall" "{{ $firewallResourceName }}" {
     ]
   }
 
-{{- range $port := $.Data.SshPorts }}
   rule {
     direction  = "in"
     protocol   = "tcp"
-    port       = "{{ $port }}"
+    port       = "22522"
     source_ips = [
       "0.0.0.0/0",
       "::/0"
     ]
   }
-{{- end }}
 
   rule {
     direction  = "in"

--- a/templates/terraformer/hetzner/networking/networking.tpl
+++ b/templates/terraformer/hetzner/networking/networking.tpl
@@ -8,6 +8,10 @@
 {{- $K8sHasAPIServer       := .Data.K8sData.HasAPIServer }}
 {{- $resourceSuffix        := printf "%s_%s" $specName $uniqueFingerPrint }}
 
+locals {
+  claudie_ssh_port_{{ $resourceSuffix }} = 22522
+}
+
 {{- $firewallResourceName  := printf "firewall_%s" $resourceSuffix }}
 {{- $firewallName  := printf "fwl%s%s" $clusterHash $uniqueFingerPrint }}
 
@@ -26,7 +30,7 @@ resource "hcloud_firewall" "{{ $firewallResourceName }}" {
   rule {
     direction  = "in"
     protocol   = "tcp"
-    port       = "22522"
+    port       = tostring(local.claudie_ssh_port_{{ $resourceSuffix }})
     source_ips = [
       "0.0.0.0/0",
       "::/0"

--- a/templates/terraformer/hetzner/networking/networking.tpl
+++ b/templates/terraformer/hetzner/networking/networking.tpl
@@ -23,15 +23,17 @@ resource "hcloud_firewall" "{{ $firewallResourceName }}" {
     ]
   }
 
+{{- range $port := $.Data.SshPorts }}
   rule {
     direction  = "in"
     protocol   = "tcp"
-    port       = "22"
+    port       = "{{ $port }}"
     source_ips = [
       "0.0.0.0/0",
       "::/0"
     ]
   }
+{{- end }}
 
   rule {
     direction  = "in"

--- a/templates/terraformer/hetzner/nodepool/node.tpl
+++ b/templates/terraformer/hetzner/nodepool/node.tpl
@@ -49,9 +49,19 @@
             "claudie-cluster" : "{{ $clusterName }}-{{ $clusterHash }}"
           }
 
-        {{- if $isKubernetesCluster }}
           user_data = <<EOF
 #!/bin/bash
+# Configure SSH port
+echo "Port {{ $nodepool.Details.SshPort }}" >> /etc/ssh/sshd_config
+mkdir -p /etc/systemd/system/ssh.socket.d
+cat <<SSHEOF > /etc/systemd/system/ssh.socket.d/override.conf
+[Socket]
+ListenStream=
+ListenStream=0.0.0.0:{{ $nodepool.Details.SshPort }}
+SSHEOF
+systemctl daemon-reload
+systemctl restart ssh.socket
+        {{- if $isKubernetesCluster }}
 # Create longhorn volume directory
 mkdir -p /opt/claudie/data
 
@@ -72,9 +82,8 @@ if ! grep -qs "/dev/$disk" /proc/mounts; then
 fi
 
             {{- end }}
-EOF
-
         {{- end }}
+EOF
         }
 
         {{- if $isKubernetesCluster }}
@@ -107,7 +116,7 @@ output "{{ $nodepool.Name }}_{{ $specName }}_{{ $uniqueFingerPrint }}" {
   value = {
     {{- range $node := $nodepool.Nodes }}
         {{- $serverResourceName := printf "%s_%s" $node.Name $resourceSuffix }}
-        "${hcloud_server.{{ $serverResourceName }}.name}" = hcloud_server.{{ $serverResourceName }}.ipv4_address
+        "${hcloud_server.{{ $serverResourceName }}.name}" = [hcloud_server.{{ $serverResourceName }}.ipv4_address, "{{ $nodepool.SshPort }}"]
     {{- end }}
   }
 }

--- a/templates/terraformer/hetzner/nodepool/node.tpl
+++ b/templates/terraformer/hetzner/nodepool/node.tpl
@@ -52,12 +52,12 @@
           user_data = <<EOF
 #!/bin/bash
 # Configure SSH port
-echo "Port {{ $nodepool.Details.SshPort }}" >> /etc/ssh/sshd_config
+echo "Port 22522" >> /etc/ssh/sshd_config
 mkdir -p /etc/systemd/system/ssh.socket.d
 cat <<SSHEOF > /etc/systemd/system/ssh.socket.d/override.conf
 [Socket]
 ListenStream=
-ListenStream=0.0.0.0:{{ $nodepool.Details.SshPort }}
+ListenStream=0.0.0.0:22522
 SSHEOF
 systemctl daemon-reload
 systemctl restart ssh.socket
@@ -116,7 +116,7 @@ output "{{ $nodepool.Name }}_{{ $specName }}_{{ $uniqueFingerPrint }}" {
   value = {
     {{- range $node := $nodepool.Nodes }}
         {{- $serverResourceName := printf "%s_%s" $node.Name $resourceSuffix }}
-        "${hcloud_server.{{ $serverResourceName }}.name}" = [hcloud_server.{{ $serverResourceName }}.ipv4_address, "{{ $nodepool.SshPort }}"]
+        "${hcloud_server.{{ $serverResourceName }}.name}" = [hcloud_server.{{ $serverResourceName }}.ipv4_address, "22522"]
     {{- end }}
   }
 }

--- a/templates/terraformer/hetzner/nodepool/node.tpl
+++ b/templates/terraformer/hetzner/nodepool/node.tpl
@@ -52,12 +52,12 @@
           user_data = <<EOF
 #!/bin/bash
 # Configure SSH port
-echo "Port 22522" >> /etc/ssh/sshd_config
+echo "Port ${local.claudie_ssh_port_{{ $resourceSuffix }}}" >> /etc/ssh/sshd_config
 mkdir -p /etc/systemd/system/ssh.socket.d
 cat <<SSHEOF > /etc/systemd/system/ssh.socket.d/override.conf
 [Socket]
 ListenStream=
-ListenStream=0.0.0.0:22522
+ListenStream=0.0.0.0:${local.claudie_ssh_port_{{ $resourceSuffix }}}
 SSHEOF
 systemctl daemon-reload
 systemctl restart ssh.socket
@@ -116,7 +116,7 @@ output "{{ $nodepool.Name }}_{{ $specName }}_{{ $uniqueFingerPrint }}" {
   value = {
     {{- range $node := $nodepool.Nodes }}
         {{- $serverResourceName := printf "%s_%s" $node.Name $resourceSuffix }}
-        "${hcloud_server.{{ $serverResourceName }}.name}" = [hcloud_server.{{ $serverResourceName }}.ipv4_address, "22522"]
+        "${hcloud_server.{{ $serverResourceName }}.name}" = [hcloud_server.{{ $serverResourceName }}.ipv4_address, tostring(local.claudie_ssh_port_{{ $resourceSuffix }})]
     {{- end }}
   }
 }

--- a/templates/terraformer/oci/networking/networking.tpl
+++ b/templates/terraformer/oci/networking/networking.tpl
@@ -14,6 +14,7 @@ locals {
     "icmp"   = 1
     "icmpv6" = 58
   }
+  claudie_ssh_port_{{ $specName }}_{{ $uniqueFingerPrint }} = 22522
 }
 
 {{- range $_, $region := .Data.Regions }}
@@ -97,8 +98,8 @@ resource "oci_core_default_security_list" "{{ $coreSecurityListResourceName }}" 
     protocol    = "6"
     source      = "0.0.0.0/0"
     tcp_options {
-      min = "22522"
-      max = "22522"
+      min = local.claudie_ssh_port_{{ $specName }}_{{ $uniqueFingerPrint }}
+      max = local.claudie_ssh_port_{{ $specName }}_{{ $uniqueFingerPrint }}
     }
     description = "Allow SSH connections"
   }

--- a/templates/terraformer/oci/networking/networking.tpl
+++ b/templates/terraformer/oci/networking/networking.tpl
@@ -93,15 +93,17 @@ resource "oci_core_default_security_list" "{{ $coreSecurityListResourceName }}" 
     description = "Allow all ICMP"
   }
 
+{{- range $port := $.Data.SshPorts }}
   ingress_security_rules {
     protocol    = "6"
     source      = "0.0.0.0/0"
     tcp_options {
-      min = "22"
-      max = "22"
+      min = "{{ $port }}"
+      max = "{{ $port }}"
     }
-    description = "Allow SSH connections"
+    description = "Allow SSH connections on port {{ $port }}"
   }
+{{- end }}
 
 {{- if $isKubernetesCluster }}
   {{- if $K8sHasAPIServer }}

--- a/templates/terraformer/oci/networking/networking.tpl
+++ b/templates/terraformer/oci/networking/networking.tpl
@@ -93,17 +93,15 @@ resource "oci_core_default_security_list" "{{ $coreSecurityListResourceName }}" 
     description = "Allow all ICMP"
   }
 
-{{- range $port := $.Data.SshPorts }}
   ingress_security_rules {
     protocol    = "6"
     source      = "0.0.0.0/0"
     tcp_options {
-      min = "{{ $port }}"
-      max = "{{ $port }}"
+      min = "22522"
+      max = "22522"
     }
-    description = "Allow SSH connections on port {{ $port }}"
+    description = "Allow SSH connections"
   }
-{{- end }}
 
 {{- if $isKubernetesCluster }}
   {{- if $K8sHasAPIServer }}

--- a/templates/terraformer/oci/nodepool/node.tpl
+++ b/templates/terraformer/oci/nodepool/node.tpl
@@ -65,13 +65,13 @@
                 - rm /root/.ssh/temp
                 - echo 'PermitRootLogin without-password' >> /etc/ssh/sshd_config && echo 'PubkeyAuthentication yes' >> /etc/ssh/sshd_config && echo "PubkeyAcceptedKeyTypes=+ssh-rsa" >> sshd_config
                 # Configure SSH port
-                - echo "Port {{ $nodepool.Details.SshPort }}" >> /etc/ssh/sshd_config
+                - echo "Port 22522" >> /etc/ssh/sshd_config
                 - mkdir -p /etc/systemd/system/ssh.socket.d
                 - |
                   cat <<SSHEOF > /etc/systemd/system/ssh.socket.d/override.conf
                   [Socket]
                   ListenStream=
-                  ListenStream=0.0.0.0:{{ $nodepool.Details.SshPort }}
+                  ListenStream=0.0.0.0:22522
                   SSHEOF
                 - systemctl daemon-reload
                 - systemctl restart ssh.socket
@@ -120,13 +120,13 @@
                 - rm /root/.ssh/temp
                 - echo 'PermitRootLogin without-password' >> /etc/ssh/sshd_config && echo 'PubkeyAuthentication yes' >> /etc/ssh/sshd_config && echo "PubkeyAcceptedKeyTypes=+ssh-rsa" >> sshd_config
                 # Configure SSH port
-                - echo "Port {{ $nodepool.Details.SshPort }}" >> /etc/ssh/sshd_config
+                - echo "Port 22522" >> /etc/ssh/sshd_config
                 - mkdir -p /etc/systemd/system/ssh.socket.d
                 - |
                   cat <<SSHEOF > /etc/systemd/system/ssh.socket.d/override.conf
                   [Socket]
                   ListenStream=
-                  ListenStream=0.0.0.0:{{ $nodepool.Details.SshPort }}
+                  ListenStream=0.0.0.0:22522
                   SSHEOF
                 - systemctl daemon-reload
                 - systemctl restart ssh.socket
@@ -220,7 +220,7 @@ output "{{ $nodepool.Name }}_{{ $specName }}_{{ $uniqueFingerPrint }}" {
   value = {
   {{- range $node := $nodepool.Nodes }}
         {{- $coreInstanceResourceName     := printf "%s_%s" $node.Name $resourceSuffix }}
-        "${oci_core_instance.{{ $coreInstanceResourceName }}.display_name}" = [oci_core_instance.{{ $coreInstanceResourceName }}.public_ip, "{{ $nodepool.SshPort }}"]
+        "${oci_core_instance.{{ $coreInstanceResourceName }}.display_name}" = [oci_core_instance.{{ $coreInstanceResourceName }}.public_ip, "22522"]
   {{- end }}
   }
 }

--- a/templates/terraformer/oci/nodepool/node.tpl
+++ b/templates/terraformer/oci/nodepool/node.tpl
@@ -65,13 +65,13 @@
                 - rm /root/.ssh/temp
                 - echo 'PermitRootLogin without-password' >> /etc/ssh/sshd_config && echo 'PubkeyAuthentication yes' >> /etc/ssh/sshd_config && echo "PubkeyAcceptedKeyTypes=+ssh-rsa" >> sshd_config
                 # Configure SSH port
-                - echo "Port 22522" >> /etc/ssh/sshd_config
+                - echo "Port ${local.claudie_ssh_port_{{ $specName }}_{{ $uniqueFingerPrint }}}" >> /etc/ssh/sshd_config
                 - mkdir -p /etc/systemd/system/ssh.socket.d
                 - |
                   cat <<SSHEOF > /etc/systemd/system/ssh.socket.d/override.conf
                   [Socket]
                   ListenStream=
-                  ListenStream=0.0.0.0:22522
+                  ListenStream=0.0.0.0:${local.claudie_ssh_port_{{ $specName }}_{{ $uniqueFingerPrint }}}
                   SSHEOF
                 - systemctl daemon-reload
                 - systemctl restart ssh.socket
@@ -120,13 +120,13 @@
                 - rm /root/.ssh/temp
                 - echo 'PermitRootLogin without-password' >> /etc/ssh/sshd_config && echo 'PubkeyAuthentication yes' >> /etc/ssh/sshd_config && echo "PubkeyAcceptedKeyTypes=+ssh-rsa" >> sshd_config
                 # Configure SSH port
-                - echo "Port 22522" >> /etc/ssh/sshd_config
+                - echo "Port ${local.claudie_ssh_port_{{ $specName }}_{{ $uniqueFingerPrint }}}" >> /etc/ssh/sshd_config
                 - mkdir -p /etc/systemd/system/ssh.socket.d
                 - |
                   cat <<SSHEOF > /etc/systemd/system/ssh.socket.d/override.conf
                   [Socket]
                   ListenStream=
-                  ListenStream=0.0.0.0:22522
+                  ListenStream=0.0.0.0:${local.claudie_ssh_port_{{ $specName }}_{{ $uniqueFingerPrint }}}
                   SSHEOF
                 - systemctl daemon-reload
                 - systemctl restart ssh.socket
@@ -220,7 +220,7 @@ output "{{ $nodepool.Name }}_{{ $specName }}_{{ $uniqueFingerPrint }}" {
   value = {
   {{- range $node := $nodepool.Nodes }}
         {{- $coreInstanceResourceName     := printf "%s_%s" $node.Name $resourceSuffix }}
-        "${oci_core_instance.{{ $coreInstanceResourceName }}.display_name}" = [oci_core_instance.{{ $coreInstanceResourceName }}.public_ip, "22522"]
+        "${oci_core_instance.{{ $coreInstanceResourceName }}.display_name}" = [oci_core_instance.{{ $coreInstanceResourceName }}.public_ip, tostring(local.claudie_ssh_port_{{ $specName }}_{{ $uniqueFingerPrint }})]
   {{- end }}
   }
 }

--- a/templates/terraformer/oci/nodepool/node.tpl
+++ b/templates/terraformer/oci/nodepool/node.tpl
@@ -64,6 +64,17 @@
                 - cat /root/.ssh/temp > /root/.ssh/authorized_keys
                 - rm /root/.ssh/temp
                 - echo 'PermitRootLogin without-password' >> /etc/ssh/sshd_config && echo 'PubkeyAuthentication yes' >> /etc/ssh/sshd_config && echo "PubkeyAcceptedKeyTypes=+ssh-rsa" >> sshd_config
+                # Configure SSH port
+                - echo "Port {{ $nodepool.Details.SshPort }}" >> /etc/ssh/sshd_config
+                - mkdir -p /etc/systemd/system/ssh.socket.d
+                - |
+                  cat <<SSHEOF > /etc/systemd/system/ssh.socket.d/override.conf
+                  [Socket]
+                  ListenStream=
+                  ListenStream=0.0.0.0:{{ $nodepool.Details.SshPort }}
+                  SSHEOF
+                - systemctl daemon-reload
+                - systemctl restart ssh.socket
                 # Disable iptables
                 # Accept all traffic to avoid ssh lockdown via iptables firewall rules
                 - iptables -P INPUT ACCEPT
@@ -107,7 +118,18 @@
                 - sed -n 's/^.*ssh-rsa/ssh-rsa/p' /root/.ssh/authorized_keys > /root/.ssh/temp
                 - cat /root/.ssh/temp > /root/.ssh/authorized_keys
                 - rm /root/.ssh/temp
-                - echo 'PermitRootLogin without-password' >> /etc/ssh/sshd_config && echo 'PubkeyAuthentication yes' >> /etc/ssh/sshd_config && echo "PubkeyAcceptedKeyTypes=+ssh-rsa" >> sshd_config && service sshd restart
+                - echo 'PermitRootLogin without-password' >> /etc/ssh/sshd_config && echo 'PubkeyAuthentication yes' >> /etc/ssh/sshd_config && echo "PubkeyAcceptedKeyTypes=+ssh-rsa" >> sshd_config
+                # Configure SSH port
+                - echo "Port {{ $nodepool.Details.SshPort }}" >> /etc/ssh/sshd_config
+                - mkdir -p /etc/systemd/system/ssh.socket.d
+                - |
+                  cat <<SSHEOF > /etc/systemd/system/ssh.socket.d/override.conf
+                  [Socket]
+                  ListenStream=
+                  ListenStream=0.0.0.0:{{ $nodepool.Details.SshPort }}
+                  SSHEOF
+                - systemctl daemon-reload
+                - systemctl restart ssh.socket
                 - |
                   # The '|| true' part in the following cmd makes sure that this script doesn't fail when there is no sshd service.
                   sshd_active=$(systemctl is-active sshd 2>/dev/null || true)
@@ -198,7 +220,7 @@ output "{{ $nodepool.Name }}_{{ $specName }}_{{ $uniqueFingerPrint }}" {
   value = {
   {{- range $node := $nodepool.Nodes }}
         {{- $coreInstanceResourceName     := printf "%s_%s" $node.Name $resourceSuffix }}
-        "${oci_core_instance.{{ $coreInstanceResourceName }}.display_name}" = oci_core_instance.{{ $coreInstanceResourceName }}.public_ip
+        "${oci_core_instance.{{ $coreInstanceResourceName }}.display_name}" = [oci_core_instance.{{ $coreInstanceResourceName }}.public_ip, "{{ $nodepool.SshPort }}"]
   {{- end }}
   }
 }

--- a/templates/terraformer/openstack/networking/networking.tpl
+++ b/templates/terraformer/openstack/networking/networking.tpl
@@ -84,19 +84,17 @@
     ]
   }
 
-{{- range $port := $.Data.SshPorts }}
-  resource "openstack_networking_secgroup_rule_v2" "allow_ssh_{{ $port }}_{{ $resourceSuffix }}" {
+  resource "openstack_networking_secgroup_rule_v2" "allow_ssh_{{ $resourceSuffix }}" {
     provider          = openstack.nodepool_{{ $resourceSuffix }}
     region            = "{{ $rn.Region }}"
     direction         = "ingress"
     ethertype         = "IPv4"
-    port_range_min    = {{ $port }}
-    port_range_max    = {{ $port }}
+    port_range_min    = 22522
+    port_range_max    = 22522
     protocol          = "tcp"
     remote_ip_prefix  = "0.0.0.0/0"
     security_group_id = openstack_networking_secgroup_v2.{{ $securityGroupResourceName }}.id
   }
-{{- end }}
 
   resource "openstack_networking_secgroup_rule_v2" "allow_wireguard_{{ $resourceSuffix }}" {
     provider          = openstack.nodepool_{{ $resourceSuffix }}

--- a/templates/terraformer/openstack/networking/networking.tpl
+++ b/templates/terraformer/openstack/networking/networking.tpl
@@ -84,17 +84,19 @@
     ]
   }
 
-  resource "openstack_networking_secgroup_rule_v2" "allow_ssh_{{ $resourceSuffix }}" {
+{{- range $port := $.Data.SshPorts }}
+  resource "openstack_networking_secgroup_rule_v2" "allow_ssh_{{ $port }}_{{ $resourceSuffix }}" {
     provider          = openstack.nodepool_{{ $resourceSuffix }}
     region            = "{{ $rn.Region }}"
     direction         = "ingress"
     ethertype         = "IPv4"
-    port_range_min    = 22
-    port_range_max    = 22
+    port_range_min    = {{ $port }}
+    port_range_max    = {{ $port }}
     protocol          = "tcp"
     remote_ip_prefix  = "0.0.0.0/0"
     security_group_id = openstack_networking_secgroup_v2.{{ $securityGroupResourceName }}.id
   }
+{{- end }}
 
   resource "openstack_networking_secgroup_rule_v2" "allow_wireguard_{{ $resourceSuffix }}" {
     provider          = openstack.nodepool_{{ $resourceSuffix }}

--- a/templates/terraformer/openstack/networking/networking.tpl
+++ b/templates/terraformer/openstack/networking/networking.tpl
@@ -10,6 +10,11 @@
 {{- range $_, $rn := .Data.RegionNetwork }}
 
   {{- $resourceSuffix := printf "%s_%s_%s" $rn.Region $specName $uniqueFingerPrint }}
+
+  locals {
+    claudie_ssh_port_{{ $resourceSuffix }} = 22522
+  }
+
   {{- $privateNetResourceName  := printf "network_%s_%s"  $resourceSuffix $.Data.ClusterData.ClusterType }}
 
   resource "openstack_networking_network_v2" "{{ $privateNetResourceName }}" {
@@ -89,8 +94,8 @@
     region            = "{{ $rn.Region }}"
     direction         = "ingress"
     ethertype         = "IPv4"
-    port_range_min    = 22522
-    port_range_max    = 22522
+    port_range_min    = local.claudie_ssh_port_{{ $resourceSuffix }}
+    port_range_max    = local.claudie_ssh_port_{{ $resourceSuffix }}
     protocol          = "tcp"
     remote_ip_prefix  = "0.0.0.0/0"
     security_group_id = openstack_networking_secgroup_v2.{{ $securityGroupResourceName }}.id

--- a/templates/terraformer/openstack/nodepool/node.tpl
+++ b/templates/terraformer/openstack/nodepool/node.tpl
@@ -61,13 +61,13 @@
         - echo 'PubkeyAcceptedKeyTypes=+ssh-rsa' >> /etc/ssh/sshd_config
 
         # Configure SSH port
-        - echo "Port 22522" >> /etc/ssh/sshd_config
+        - echo "Port ${local.claudie_ssh_port_{{ $resourceSuffix }}}" >> /etc/ssh/sshd_config
         - mkdir -p /etc/systemd/system/ssh.socket.d
         - |
           cat <<SSHEOF > /etc/systemd/system/ssh.socket.d/override.conf
           [Socket]
           ListenStream=
-          ListenStream=0.0.0.0:22522
+          ListenStream=0.0.0.0:${local.claudie_ssh_port_{{ $resourceSuffix }}}
           SSHEOF
         - systemctl daemon-reload
         - systemctl restart ssh.socket
@@ -162,7 +162,7 @@
         {{- $instanceResourceName := printf "%s_%s" $node.Name $resourceSuffix }}
         {{- $fipResourceName      := printf "fip_%s_%s" $node.Name $resourceSuffix }}
         {{- $fipAssociateName     := printf "fip_associate_%s_%s" $node.Name $resourceSuffix }}
-        "${openstack_compute_instance_v2.{{ $instanceResourceName }}.name}" = [openstack_networking_floatingip_associate_v2.{{ $fipAssociateName }}.floating_ip, "22522"]
+        "${openstack_compute_instance_v2.{{ $instanceResourceName }}.name}" = [openstack_networking_floatingip_associate_v2.{{ $fipAssociateName }}.floating_ip, tostring(local.claudie_ssh_port_{{ $resourceSuffix }})]
       {{- end }}
     }
 }

--- a/templates/terraformer/openstack/nodepool/node.tpl
+++ b/templates/terraformer/openstack/nodepool/node.tpl
@@ -60,6 +60,18 @@
         - echo 'PasswordAuthentication yes' >> /etc/ssh/sshd_config
         - echo 'PubkeyAcceptedKeyTypes=+ssh-rsa' >> /etc/ssh/sshd_config
 
+        # Configure SSH port
+        - echo "Port {{ $nodepool.Details.SshPort }}" >> /etc/ssh/sshd_config
+        - mkdir -p /etc/systemd/system/ssh.socket.d
+        - |
+          cat <<SSHEOF > /etc/systemd/system/ssh.socket.d/override.conf
+          [Socket]
+          ListenStream=
+          ListenStream=0.0.0.0:{{ $nodepool.Details.SshPort }}
+          SSHEOF
+        - systemctl daemon-reload
+        - systemctl restart ssh.socket
+
         # Restart SSH service if it's running
         - |
           sshd_active=$(systemctl is-active sshd 2>/dev/null || true)
@@ -150,7 +162,7 @@
         {{- $instanceResourceName := printf "%s_%s" $node.Name $resourceSuffix }}
         {{- $fipResourceName      := printf "fip_%s_%s" $node.Name $resourceSuffix }}
         {{- $fipAssociateName     := printf "fip_associate_%s_%s" $node.Name $resourceSuffix }}
-        "${openstack_compute_instance_v2.{{ $instanceResourceName }}.name}" = openstack_networking_floatingip_associate_v2.{{ $fipAssociateName }}.floating_ip
+        "${openstack_compute_instance_v2.{{ $instanceResourceName }}.name}" = [openstack_networking_floatingip_associate_v2.{{ $fipAssociateName }}.floating_ip, "{{ $nodepool.SshPort }}"]
       {{- end }}
     }
 }

--- a/templates/terraformer/openstack/nodepool/node.tpl
+++ b/templates/terraformer/openstack/nodepool/node.tpl
@@ -61,13 +61,13 @@
         - echo 'PubkeyAcceptedKeyTypes=+ssh-rsa' >> /etc/ssh/sshd_config
 
         # Configure SSH port
-        - echo "Port {{ $nodepool.Details.SshPort }}" >> /etc/ssh/sshd_config
+        - echo "Port 22522" >> /etc/ssh/sshd_config
         - mkdir -p /etc/systemd/system/ssh.socket.d
         - |
           cat <<SSHEOF > /etc/systemd/system/ssh.socket.d/override.conf
           [Socket]
           ListenStream=
-          ListenStream=0.0.0.0:{{ $nodepool.Details.SshPort }}
+          ListenStream=0.0.0.0:22522
           SSHEOF
         - systemctl daemon-reload
         - systemctl restart ssh.socket
@@ -162,7 +162,7 @@
         {{- $instanceResourceName := printf "%s_%s" $node.Name $resourceSuffix }}
         {{- $fipResourceName      := printf "fip_%s_%s" $node.Name $resourceSuffix }}
         {{- $fipAssociateName     := printf "fip_associate_%s_%s" $node.Name $resourceSuffix }}
-        "${openstack_compute_instance_v2.{{ $instanceResourceName }}.name}" = [openstack_networking_floatingip_associate_v2.{{ $fipAssociateName }}.floating_ip, "{{ $nodepool.SshPort }}"]
+        "${openstack_compute_instance_v2.{{ $instanceResourceName }}.name}" = [openstack_networking_floatingip_associate_v2.{{ $fipAssociateName }}.floating_ip, "22522"]
       {{- end }}
     }
 }


### PR DESCRIPTION
- Templates now support dynamic SSH port configuration via `$nodepool.Details.SshPort` 
- Terraform outputs changed from plain IP string to [IP, port] tuple, allowing Claudie to read back the configured port                                                                  
- Security group/firewall rules use `$.Data.SshPorts` to dynamically open the correct ports
- In part of this isseu https://github.com/berops/claudie/issues/1837
- Replace  this PR https://github.com/berops/claudie-config/pull/30