### PR TITLE
feat: add Verda provider templates

### DIFF
--- a/templates/terraformer/verda/networking/networking.tpl
+++ b/templates/terraformer/verda/networking/networking.tpl
@@ -15,12 +15,13 @@
 # so that nodepool/node.tpl can reference it from the verda_startup_script body.
 
 locals {
+  claudie_ssh_port_{{ $resourceSuffix }} = 22522
   verda_firewall_script_{{ $resourceSuffix }} = <<-FWSCRIPT
 # Allow established connections and loopback
 iptables -A INPUT -m state --state ESTABLISHED,RELATED -j ACCEPT
 iptables -A INPUT -i lo -j ACCEPT
 # Allow SSH
-iptables -A INPUT -p tcp --dport 22 -j ACCEPT
+iptables -A INPUT -p tcp --dport ${local.claudie_ssh_port_{{ $resourceSuffix }}} -j ACCEPT
 # Allow WireGuard
 iptables -A INPUT -p udp --dport 51820 -j ACCEPT
 {{- if $isKubernetesCluster }}

--- a/templates/terraformer/verda/networking/networking.tpl
+++ b/templates/terraformer/verda/networking/networking.tpl
@@ -1,0 +1,51 @@
+{{- $clusterName           := .Data.ClusterData.ClusterName}}
+{{- $clusterHash           := .Data.ClusterData.ClusterHash}}
+{{- $specName              := .Data.Provider.SpecName }}
+{{- $uniqueFingerPrint     := .Fingerprint }}
+{{- $isKubernetesCluster   := eq .Data.ClusterData.ClusterType "K8s" }}
+{{- $isLoadbalancerCluster := eq .Data.ClusterData.ClusterType "LB" }}
+{{- $LoadBalancerRoles     := .Data.LBData.Roles }}
+{{- $K8sHasAPIServer       := .Data.K8sData.HasAPIServer }}
+{{- $resourceSuffix        := printf "%s_%s" $specName $uniqueFingerPrint }}
+
+# Verda does not provide cloud-level firewall or networking resources.
+# Direct iptables rules are used instead of UFW because KubeOne disables UFW
+# during node provisioning. KubeOne does not flush iptables INPUT rules.
+# This template generates the firewall script as a Terraform local
+# so that nodepool/node.tpl can reference it from the verda_startup_script body.
+
+locals {
+  verda_firewall_script_{{ $resourceSuffix }} = <<-FWSCRIPT
+# Allow established connections and loopback
+iptables -A INPUT -m state --state ESTABLISHED,RELATED -j ACCEPT
+iptables -A INPUT -i lo -j ACCEPT
+# Allow SSH
+iptables -A INPUT -p tcp --dport 22 -j ACCEPT
+# Allow WireGuard
+iptables -A INPUT -p udp --dport 51820 -j ACCEPT
+{{- if $isKubernetesCluster }}
+# Allow K8s API server
+iptables -A INPUT -p tcp --dport 6443 -j ACCEPT
+# Allow kubelet API
+iptables -A INPUT -p tcp --dport 10250 -j ACCEPT
+{{- end }}
+{{- if $isLoadbalancerCluster }}
+  {{- range $role := $LoadBalancerRoles }}
+iptables -A INPUT -p {{ lower $role.Protocol }} --dport {{ $role.Port }} -j ACCEPT
+  {{- end }}
+{{- end }}
+# Allow ICMP
+iptables -A INPUT -p icmp -j ACCEPT
+# Allow all traffic on WireGuard tunnel interface
+iptables -A INPUT -i wg0 -j ACCEPT
+# Set default policy to drop everything else
+iptables -P INPUT DROP
+# Block IPv6 traffic but allow loopback (kube-apiserver uses [::1]:6443 internally)
+ip6tables -A INPUT -i lo -j ACCEPT
+ip6tables -P INPUT DROP
+ip6tables -P FORWARD DROP
+# Persist rules across reboots
+DEBIAN_FRONTEND=noninteractive apt-get install -y -qq iptables-persistent > /dev/null 2>&1 || true
+iptables-save > /etc/iptables/rules.v4
+FWSCRIPT
+}

--- a/templates/terraformer/verda/nodepool/node.tpl
+++ b/templates/terraformer/verda/nodepool/node.tpl
@@ -1,0 +1,121 @@
+{{- $clusterName           := .Data.ClusterData.ClusterName}}
+{{- $clusterHash           := .Data.ClusterData.ClusterHash}}
+{{- $uniqueFingerPrint     := .Fingerprint }}
+{{- $isKubernetesCluster   := eq .Data.ClusterData.ClusterType "K8s" }}
+{{- $isLoadbalancerCluster := eq .Data.ClusterData.ClusterType "LB" }}
+
+
+{{- range $nodepool := .Data.NodePools }}
+
+{{- $specName       := $nodepool.Details.Provider.SpecName }}
+{{- $resourceSuffix := printf "%s_%s" $specName $uniqueFingerPrint }}
+
+{{- $sshKeyResourceName := printf "key_%s_%s" $nodepool.Name $resourceSuffix }}
+{{- $sshKeyName         := printf "key-%s-%s-%s" $nodepool.Name $clusterHash $specName }}
+
+    resource "verda_ssh_key" "{{ $sshKeyResourceName }}" {
+      provider   = verda.nodepool_{{ $resourceSuffix }}
+      name       = "{{ $sshKeyName }}"
+      public_key = file("./{{ $nodepool.Name }}")
+    }
+
+    {{- range $node := $nodepool.Nodes }}
+
+        {{- $instanceResourceName        := printf "%s_%s" $node.Name $resourceSuffix }}
+        {{- $startupScriptResourceName   := printf "startup_%s_%s" $node.Name $resourceSuffix }}
+        {{- $startupScriptName           := printf "startup-%s-%s" $node.Name $clusterHash }}
+        {{- $isWorkerNodeWithDiskAttached := and (not $nodepool.IsControl) (gt $nodepool.Details.StorageDiskSize 0) }}
+        {{- $volumeResourceName          := printf "%s_%s_volume" $node.Name $resourceSuffix }}
+        {{- $volumeName                  := printf "vol-%s-%s" $node.Name $clusterHash }}
+
+        {{- if $isKubernetesCluster }}
+            {{- if $isWorkerNodeWithDiskAttached }}
+
+            resource "verda_volume" "{{ $volumeResourceName }}" {
+              provider = verda.nodepool_{{ $resourceSuffix }}
+              name     = "{{ $volumeName }}"
+              size     = {{ $nodepool.Details.StorageDiskSize }}
+              type     = "NVMe"
+              location = "{{ $nodepool.Details.Region }}"
+            }
+
+            {{- end }}
+        {{- end }}
+
+        resource "verda_startup_script" "{{ $startupScriptResourceName }}" {
+          provider = verda.nodepool_{{ $resourceSuffix }}
+          name     = "{{ $startupScriptName }}"
+          script   = <<-SCRIPT
+#!/bin/bash
+# Enable root SSH access
+mkdir -p /root/.ssh
+chmod 700 /root/.ssh
+if [ -f /home/ubuntu/.ssh/authorized_keys ]; then
+    sed -n 's/^.*ssh-rsa/ssh-rsa/p' /home/ubuntu/.ssh/authorized_keys > /root/.ssh/authorized_keys
+    chmod 600 /root/.ssh/authorized_keys
+fi
+echo 'PermitRootLogin without-password' >> /etc/ssh/sshd_config
+echo 'PubkeyAuthentication yes' >> /etc/ssh/sshd_config
+echo 'PubkeyAcceptedKeyTypes=+ssh-rsa' >> /etc/ssh/sshd_config
+sshd_active=$(systemctl is-active sshd 2>/dev/null || true)
+ssh_active=$(systemctl is-active ssh 2>/dev/null || true)
+if [ "$sshd_active" = "active" ]; then
+    systemctl restart sshd
+fi
+if [ "$ssh_active" = "active" ]; then
+    systemctl restart ssh
+fi
+
+# Configure iptables firewall (not UFW, KubeOne disables UFW)
+${local.verda_firewall_script_{{ $resourceSuffix }}}
+
+{{- if $isKubernetesCluster }}
+
+# Create longhorn volume directory
+mkdir -p /opt/claudie/data
+
+  {{- if $isWorkerNodeWithDiskAttached }}
+
+# Mount attached volume only when not mounted yet
+sleep 50
+disk=$(ls -l /dev/disk/by-id | grep "${verda_volume.{{ $volumeResourceName }}.id}" | awk '{print $NF}')
+disk=$(basename "$disk")
+if [ -n "$disk" ] && ! grep -qs "/dev/$disk" /proc/mounts; then
+  if ! blkid /dev/$disk | grep -q 'TYPE="xfs"'; then
+    mkfs.xfs /dev/$disk
+  fi
+  mount /dev/$disk /opt/claudie/data
+  echo "/dev/$disk /opt/claudie/data xfs defaults 0 0" >> /etc/fstab
+fi
+
+  {{- end }}
+{{- end }}
+SCRIPT
+        }
+
+        resource "verda_instance" "{{ $instanceResourceName }}" {
+          provider          = verda.nodepool_{{ $resourceSuffix }}
+          instance_type     = "{{ $nodepool.Details.ServerType }}"
+          image             = "{{ $nodepool.Details.Image }}"
+          hostname          = "{{ $node.Name }}"
+          description       = "Managed by Claudie for cluster {{ $clusterName }}-{{ $clusterHash }}"
+          location          = "{{ $nodepool.Details.Region }}"
+          ssh_key_ids       = [verda_ssh_key.{{ $sshKeyResourceName }}.id]
+          startup_script_id = verda_startup_script.{{ $startupScriptResourceName }}.id
+
+        {{- if and $isKubernetesCluster $isWorkerNodeWithDiskAttached }}
+          existing_volumes = [verda_volume.{{ $volumeResourceName }}.id]
+        {{- end }}
+        }
+
+    {{- end }}
+
+output "{{ $nodepool.Name }}_{{ $specName }}_{{ $uniqueFingerPrint }}" {
+  value = {
+    {{- range $node := $nodepool.Nodes }}
+        {{- $instanceResourceName := printf "%s_%s" $node.Name $resourceSuffix }}
+        "{{ $node.Name }}" = verda_instance.{{ $instanceResourceName }}.ip
+    {{- end }}
+  }
+}
+{{- end }}

--- a/templates/terraformer/verda/nodepool/node.tpl
+++ b/templates/terraformer/verda/nodepool/node.tpl
@@ -57,6 +57,16 @@ fi
 echo 'PermitRootLogin without-password' >> /etc/ssh/sshd_config
 echo 'PubkeyAuthentication yes' >> /etc/ssh/sshd_config
 echo 'PubkeyAcceptedKeyTypes=+ssh-rsa' >> /etc/ssh/sshd_config
+# Configure custom SSH port (Claudie convention)
+echo "Port ${local.claudie_ssh_port_{{ $resourceSuffix }}}" >> /etc/ssh/sshd_config
+mkdir -p /etc/systemd/system/ssh.socket.d
+cat <<SSHEOF > /etc/systemd/system/ssh.socket.d/override.conf
+[Socket]
+ListenStream=
+ListenStream=0.0.0.0:${local.claudie_ssh_port_{{ $resourceSuffix }}}
+SSHEOF
+systemctl daemon-reload
+systemctl restart ssh.socket
 sshd_active=$(systemctl is-active sshd 2>/dev/null || true)
 ssh_active=$(systemctl is-active ssh 2>/dev/null || true)
 if [ "$sshd_active" = "active" ]; then
@@ -114,7 +124,7 @@ SCRIPT
 # before Verda assigns the public IP, leaving verda_instance.<n>.ip null in stored
 # state for the rest of the apply. We re-fetch the IP via data.http after a wall-clock
 # wait. Remove this block once the upstream provider patches Create to call
-# waitForInstanceIP. Tracked at https://github.com/berops/claudie/issues/2068.
+# waitForInstanceIP.
 
 resource "time_sleep" "wait_for_ips_{{ $nodepool.Name }}_{{ $resourceSuffix }}" {
   depends_on = [
@@ -161,7 +171,10 @@ output "{{ $nodepool.Name }}_{{ $specName }}_{{ $uniqueFingerPrint }}" {
   value = {
     {{- range $node := $nodepool.Nodes }}
         {{- $instanceResourceName := printf "%s_%s" $node.Name $resourceSuffix }}
-        "{{ $node.Name }}" = jsondecode(data.http.ip_{{ $instanceResourceName }}.response_body).ip
+        "{{ $node.Name }}" = [
+          jsondecode(data.http.ip_{{ $instanceResourceName }}.response_body).ip,
+          tostring(local.claudie_ssh_port_{{ $resourceSuffix }}),
+        ]
     {{- end }}
   }
 }

--- a/templates/terraformer/verda/nodepool/node.tpl
+++ b/templates/terraformer/verda/nodepool/node.tpl
@@ -144,7 +144,7 @@ data "http" "verda_token_{{ $nodepool.Name }}_{{ $resourceSuffix }}" {
     "Content-Type" = "application/x-www-form-urlencoded"
     "user-agent"   = ""
   }
-  request_body = "grant_type=client_credentials&client_id={{ .Data.Provider.GetVerda.ClientId }}&client_secret=${file("./{{ $specName }}")}&scope=cloud-api-v1"
+  request_body = "grant_type=client_credentials&client_id={{ $nodepool.Details.Provider.GetVerda.ClientId }}&client_secret=${file("./{{ $specName }}")}&scope=cloud-api-v1"
 }
 
     {{- range $node := $nodepool.Nodes }}

--- a/templates/terraformer/verda/nodepool/node.tpl
+++ b/templates/terraformer/verda/nodepool/node.tpl
@@ -4,6 +4,15 @@
 {{- $isKubernetesCluster   := eq .Data.ClusterData.ClusterType "K8s" }}
 {{- $isLoadbalancerCluster := eq .Data.ClusterData.ClusterType "LB" }}
 
+{{- /*
+  Each rendered .tf file is per-provider, so all nodepools in this template
+  share the same Verda provider credentials and baseUrl. We resolve them once
+  from the first nodepool and reuse across the file-level workaround blocks.
+*/ -}}
+{{- $firstNodepool := index .Data.NodePools 0 }}
+{{- $firstSpecName := $firstNodepool.Details.Provider.SpecName }}
+{{- $verdaBaseUrl  := default "https://api.verda.com/v1" $firstNodepool.Details.Provider.GetVerda.GetBaseUrl }}
+
 
 {{- range $nodepool := .Data.NodePools }}
 
@@ -119,6 +128,7 @@ SCRIPT
         }
 
     {{- end }}
+{{- end }}
 
 # WORKAROUND: verda-cloud/terraform-provider-verda returns from verda_instance.Create
 # before Verda assigns the public IP, leaving verda_instance.<n>.ip null in stored
@@ -130,28 +140,36 @@ SCRIPT
 # so the client_secret read via file() and the access_token returned by Verda end
 # up in the cluster state file. Acceptable for now because Claudie stores state in
 # MinIO with encryption-at-rest, and the workaround is temporary.
-{{- $verdaBaseUrl := default "https://api.verda.com/v1" $nodepool.Details.Provider.GetVerda.GetBaseUrl }}
 
-resource "time_sleep" "wait_for_ips_{{ $nodepool.Name }}_{{ $resourceSuffix }}" {
+resource "time_sleep" "wait_for_ips_{{ $uniqueFingerPrint }}" {
   depends_on = [
-    {{- range $node := $nodepool.Nodes }}
-        {{- $instanceResourceName := printf "%s_%s" $node.Name $resourceSuffix }}
+    {{- range $nodepool := .Data.NodePools }}
+        {{- $resourceSuffix := printf "%s_%s" $nodepool.Details.Provider.SpecName $uniqueFingerPrint }}
+        {{- range $node := $nodepool.Nodes }}
+            {{- $instanceResourceName := printf "%s_%s" $node.Name $resourceSuffix }}
     verda_instance.{{ $instanceResourceName }},
+        {{- end }}
     {{- end }}
   ]
   create_duration = "30s"
 }
 
-data "http" "verda_token_{{ $nodepool.Name }}_{{ $resourceSuffix }}" {
-  depends_on = [time_sleep.wait_for_ips_{{ $nodepool.Name }}_{{ $resourceSuffix }}]
+data "http" "verda_token_{{ $uniqueFingerPrint }}" {
+  depends_on = [time_sleep.wait_for_ips_{{ $uniqueFingerPrint }}]
   url        = "{{ $verdaBaseUrl }}/oauth2/token"
   method     = "POST"
   request_headers = {
     "Content-Type" = "application/x-www-form-urlencoded"
     "user-agent"   = ""
   }
-  request_body = "grant_type=client_credentials&client_id={{ $nodepool.Details.Provider.GetVerda.ClientId }}&client_secret=${file("./{{ $specName }}")}&scope=cloud-api-v1"
+  request_body = "grant_type=client_credentials&client_id={{ $firstNodepool.Details.Provider.GetVerda.ClientId }}&client_secret=${file("./{{ $firstSpecName }}")}&scope=cloud-api-v1"
 }
+
+
+{{- range $nodepool := .Data.NodePools }}
+
+{{- $specName       := $nodepool.Details.Provider.SpecName }}
+{{- $resourceSuffix := printf "%s_%s" $specName $uniqueFingerPrint }}
 
     {{- range $node := $nodepool.Nodes }}
         {{- $instanceResourceName := printf "%s_%s" $node.Name $resourceSuffix }}
@@ -160,7 +178,7 @@ data "http" "ip_{{ $instanceResourceName }}" {
   url    = "{{ $verdaBaseUrl }}/instances/${verda_instance.{{ $instanceResourceName }}.id}"
   method = "GET"
   request_headers = {
-    "Authorization" = "Bearer ${jsondecode(data.http.verda_token_{{ $nodepool.Name }}_{{ $resourceSuffix }}.response_body).access_token}"
+    "Authorization" = "Bearer ${jsondecode(data.http.verda_token_{{ $uniqueFingerPrint }}.response_body).access_token}"
     "user-agent"    = ""
   }
   lifecycle {

--- a/templates/terraformer/verda/nodepool/node.tpl
+++ b/templates/terraformer/verda/nodepool/node.tpl
@@ -98,7 +98,7 @@ SCRIPT
           instance_type     = "{{ $nodepool.Details.ServerType }}"
           image             = "{{ $nodepool.Details.Image }}"
           hostname          = "{{ $node.Name }}"
-          description       = "Managed by Claudie for cluster {{ $clusterName }}-{{ $clusterHash }}"
+          description       = "Claudie {{ $clusterName }}-{{ $clusterHash }}"
           location          = "{{ $nodepool.Details.Region }}"
           ssh_key_ids       = [verda_ssh_key.{{ $sshKeyResourceName }}.id]
           startup_script_id = verda_startup_script.{{ $startupScriptResourceName }}.id
@@ -110,11 +110,58 @@ SCRIPT
 
     {{- end }}
 
+# WORKAROUND: verda-cloud/terraform-provider-verda returns from verda_instance.Create
+# before Verda assigns the public IP, leaving verda_instance.<n>.ip null in stored
+# state for the rest of the apply. We re-fetch the IP via data.http after a wall-clock
+# wait. Remove this block once the upstream provider patches Create to call
+# waitForInstanceIP. Tracked at https://github.com/berops/claudie/issues/2068.
+
+resource "time_sleep" "wait_for_ips_{{ $nodepool.Name }}_{{ $resourceSuffix }}" {
+  depends_on = [
+    {{- range $node := $nodepool.Nodes }}
+        {{- $instanceResourceName := printf "%s_%s" $node.Name $resourceSuffix }}
+    verda_instance.{{ $instanceResourceName }},
+    {{- end }}
+  ]
+  create_duration = "90s"
+}
+
+data "http" "verda_token_{{ $nodepool.Name }}_{{ $resourceSuffix }}" {
+  depends_on = [time_sleep.wait_for_ips_{{ $nodepool.Name }}_{{ $resourceSuffix }}]
+  url        = "https://api.verda.com/v1/oauth2/token"
+  method     = "POST"
+  request_headers = {
+    "Content-Type" = "application/x-www-form-urlencoded"
+    "user-agent"   = ""
+  }
+  request_body = "grant_type=client_credentials&client_id={{ .Data.Provider.GetVerda.ClientId }}&client_secret=${file("./{{ $specName }}")}&scope=cloud-api-v1"
+}
+
+    {{- range $node := $nodepool.Nodes }}
+        {{- $instanceResourceName := printf "%s_%s" $node.Name $resourceSuffix }}
+
+data "http" "ip_{{ $instanceResourceName }}" {
+  url    = "https://api.verda.com/v1/instances/${verda_instance.{{ $instanceResourceName }}.id}"
+  method = "GET"
+  request_headers = {
+    "Authorization" = "Bearer ${jsondecode(data.http.verda_token_{{ $nodepool.Name }}_{{ $resourceSuffix }}.response_body).access_token}"
+    "user-agent"    = ""
+  }
+  lifecycle {
+    postcondition {
+      condition     = jsondecode(self.response_body).ip != null && jsondecode(self.response_body).ip != ""
+      error_message = "Verda did not assign IP within wait window for instance ${verda_instance.{{ $instanceResourceName }}.id}"
+    }
+  }
+}
+
+    {{- end }}
+
 output "{{ $nodepool.Name }}_{{ $specName }}_{{ $uniqueFingerPrint }}" {
   value = {
     {{- range $node := $nodepool.Nodes }}
         {{- $instanceResourceName := printf "%s_%s" $node.Name $resourceSuffix }}
-        "{{ $node.Name }}" = verda_instance.{{ $instanceResourceName }}.ip
+        "{{ $node.Name }}" = jsondecode(data.http.ip_{{ $instanceResourceName }}.response_body).ip
     {{- end }}
   }
 }

--- a/templates/terraformer/verda/nodepool/node.tpl
+++ b/templates/terraformer/verda/nodepool/node.tpl
@@ -125,6 +125,12 @@ SCRIPT
 # state for the rest of the apply. We re-fetch the IP via data.http after a wall-clock
 # wait. Remove this block once the upstream provider patches Create to call
 # waitForInstanceIP.
+#
+# Security note: data.http stores request_body and response_body in Terraform state,
+# so the client_secret read via file() and the access_token returned by Verda end
+# up in the cluster state file. Acceptable for now because Claudie stores state in
+# MinIO with encryption-at-rest, and the workaround is temporary.
+{{- $verdaBaseUrl := default "https://api.verda.com/v1" $nodepool.Details.Provider.GetVerda.GetBaseUrl }}
 
 resource "time_sleep" "wait_for_ips_{{ $nodepool.Name }}_{{ $resourceSuffix }}" {
   depends_on = [
@@ -138,7 +144,7 @@ resource "time_sleep" "wait_for_ips_{{ $nodepool.Name }}_{{ $resourceSuffix }}" 
 
 data "http" "verda_token_{{ $nodepool.Name }}_{{ $resourceSuffix }}" {
   depends_on = [time_sleep.wait_for_ips_{{ $nodepool.Name }}_{{ $resourceSuffix }}]
-  url        = "https://api.verda.com/v1/oauth2/token"
+  url        = "{{ $verdaBaseUrl }}/oauth2/token"
   method     = "POST"
   request_headers = {
     "Content-Type" = "application/x-www-form-urlencoded"
@@ -151,7 +157,7 @@ data "http" "verda_token_{{ $nodepool.Name }}_{{ $resourceSuffix }}" {
         {{- $instanceResourceName := printf "%s_%s" $node.Name $resourceSuffix }}
 
 data "http" "ip_{{ $instanceResourceName }}" {
-  url    = "https://api.verda.com/v1/instances/${verda_instance.{{ $instanceResourceName }}.id}"
+  url    = "{{ $verdaBaseUrl }}/instances/${verda_instance.{{ $instanceResourceName }}.id}"
   method = "GET"
   request_headers = {
     "Authorization" = "Bearer ${jsondecode(data.http.verda_token_{{ $nodepool.Name }}_{{ $resourceSuffix }}.response_body).access_token}"

--- a/templates/terraformer/verda/nodepool/node.tpl
+++ b/templates/terraformer/verda/nodepool/node.tpl
@@ -51,7 +51,7 @@
 mkdir -p /root/.ssh
 chmod 700 /root/.ssh
 if [ -f /home/ubuntu/.ssh/authorized_keys ]; then
-    sed -n 's/^.*ssh-rsa/ssh-rsa/p' /home/ubuntu/.ssh/authorized_keys > /root/.ssh/authorized_keys
+    cp /home/ubuntu/.ssh/authorized_keys /root/.ssh/authorized_keys
     chmod 600 /root/.ssh/authorized_keys
 fi
 echo 'PermitRootLogin without-password' >> /etc/ssh/sshd_config

--- a/templates/terraformer/verda/nodepool/node.tpl
+++ b/templates/terraformer/verda/nodepool/node.tpl
@@ -139,7 +139,7 @@ resource "time_sleep" "wait_for_ips_{{ $nodepool.Name }}_{{ $resourceSuffix }}" 
     verda_instance.{{ $instanceResourceName }},
     {{- end }}
   ]
-  create_duration = "30s"
+  create_duration = "120s"
 }
 
 data "http" "verda_token_{{ $nodepool.Name }}_{{ $resourceSuffix }}" {

--- a/templates/terraformer/verda/nodepool/node.tpl
+++ b/templates/terraformer/verda/nodepool/node.tpl
@@ -4,15 +4,6 @@
 {{- $isKubernetesCluster   := eq .Data.ClusterData.ClusterType "K8s" }}
 {{- $isLoadbalancerCluster := eq .Data.ClusterData.ClusterType "LB" }}
 
-{{- /*
-  Each rendered .tf file is per-provider, so all nodepools in this template
-  share the same Verda provider credentials and baseUrl. We resolve them once
-  from the first nodepool and reuse across the file-level workaround blocks.
-*/ -}}
-{{- $firstNodepool := index .Data.NodePools 0 }}
-{{- $firstSpecName := $firstNodepool.Details.Provider.SpecName }}
-{{- $verdaBaseUrl  := default "https://api.verda.com/v1" $firstNodepool.Details.Provider.GetVerda.GetBaseUrl }}
-
 
 {{- range $nodepool := .Data.NodePools }}
 
@@ -128,7 +119,6 @@ SCRIPT
         }
 
     {{- end }}
-{{- end }}
 
 # WORKAROUND: verda-cloud/terraform-provider-verda returns from verda_instance.Create
 # before Verda assigns the public IP, leaving verda_instance.<n>.ip null in stored
@@ -140,36 +130,28 @@ SCRIPT
 # so the client_secret read via file() and the access_token returned by Verda end
 # up in the cluster state file. Acceptable for now because Claudie stores state in
 # MinIO with encryption-at-rest, and the workaround is temporary.
+{{- $verdaBaseUrl := default "https://api.verda.com/v1" $nodepool.Details.Provider.GetVerda.GetBaseUrl }}
 
-resource "time_sleep" "wait_for_ips_{{ $uniqueFingerPrint }}" {
+resource "time_sleep" "wait_for_ips_{{ $nodepool.Name }}_{{ $resourceSuffix }}" {
   depends_on = [
-    {{- range $nodepool := .Data.NodePools }}
-        {{- $resourceSuffix := printf "%s_%s" $nodepool.Details.Provider.SpecName $uniqueFingerPrint }}
-        {{- range $node := $nodepool.Nodes }}
-            {{- $instanceResourceName := printf "%s_%s" $node.Name $resourceSuffix }}
+    {{- range $node := $nodepool.Nodes }}
+        {{- $instanceResourceName := printf "%s_%s" $node.Name $resourceSuffix }}
     verda_instance.{{ $instanceResourceName }},
-        {{- end }}
     {{- end }}
   ]
   create_duration = "30s"
 }
 
-data "http" "verda_token_{{ $uniqueFingerPrint }}" {
-  depends_on = [time_sleep.wait_for_ips_{{ $uniqueFingerPrint }}]
+data "http" "verda_token_{{ $nodepool.Name }}_{{ $resourceSuffix }}" {
+  depends_on = [time_sleep.wait_for_ips_{{ $nodepool.Name }}_{{ $resourceSuffix }}]
   url        = "{{ $verdaBaseUrl }}/oauth2/token"
   method     = "POST"
   request_headers = {
     "Content-Type" = "application/x-www-form-urlencoded"
     "user-agent"   = ""
   }
-  request_body = "grant_type=client_credentials&client_id={{ $firstNodepool.Details.Provider.GetVerda.ClientId }}&client_secret=${file("./{{ $firstSpecName }}")}&scope=cloud-api-v1"
+  request_body = "grant_type=client_credentials&client_id={{ $nodepool.Details.Provider.GetVerda.ClientId }}&client_secret=${file("./{{ $specName }}")}&scope=cloud-api-v1"
 }
-
-
-{{- range $nodepool := .Data.NodePools }}
-
-{{- $specName       := $nodepool.Details.Provider.SpecName }}
-{{- $resourceSuffix := printf "%s_%s" $specName $uniqueFingerPrint }}
 
     {{- range $node := $nodepool.Nodes }}
         {{- $instanceResourceName := printf "%s_%s" $node.Name $resourceSuffix }}
@@ -178,7 +160,7 @@ data "http" "ip_{{ $instanceResourceName }}" {
   url    = "{{ $verdaBaseUrl }}/instances/${verda_instance.{{ $instanceResourceName }}.id}"
   method = "GET"
   request_headers = {
-    "Authorization" = "Bearer ${jsondecode(data.http.verda_token_{{ $uniqueFingerPrint }}.response_body).access_token}"
+    "Authorization" = "Bearer ${jsondecode(data.http.verda_token_{{ $nodepool.Name }}_{{ $resourceSuffix }}.response_body).access_token}"
     "user-agent"    = ""
   }
   lifecycle {

--- a/templates/terraformer/verda/nodepool/node.tpl
+++ b/templates/terraformer/verda/nodepool/node.tpl
@@ -133,7 +133,7 @@ resource "time_sleep" "wait_for_ips_{{ $nodepool.Name }}_{{ $resourceSuffix }}" 
     verda_instance.{{ $instanceResourceName }},
     {{- end }}
   ]
-  create_duration = "90s"
+  create_duration = "30s"
 }
 
 data "http" "verda_token_{{ $nodepool.Name }}_{{ $resourceSuffix }}" {

--- a/templates/terraformer/verda/provider/provider.tpl
+++ b/templates/terraformer/verda/provider/provider.tpl
@@ -1,0 +1,12 @@
+{{- $specName          := .Data.Provider.SpecName }}
+{{- $uniqueFingerPrint := .Fingerprint }}
+{{- $resourceSuffix    := printf "%s_%s" $specName $uniqueFingerPrint }}
+
+provider "verda" {
+  client_id     = "{{ .Data.Provider.GetVerda.ClientId }}"
+  client_secret = file("{{ $specName }}")
+{{- if .Data.Provider.GetVerda.BaseUrl }}
+  base_url      = "{{ .Data.Provider.GetVerda.BaseUrl }}"
+{{- end }}
+  alias         = "nodepool_{{ $resourceSuffix }}"
+}


### PR DESCRIPTION
Companion to berops/claudie#2082 (Verda Cloud provider).

Adds OpenTofu templates for the new Verda Cloud provider. Branch is based on the upstream release tag v0.11.0 and includes only the new templates/terraformer/verda/ tree.

## Templates

- **provider/provider.tpl.** verda provider block, inlines client_id from proto, reads client_secret from the file written by terraformer.
- **networking/networking.tpl.** iptables firewall script as a Terraform local. KubeOne disables UFW so we use direct iptables rules. Same approach as cloudrift. Includes the claudie_ssh_port_<suffix> = 22522 local that matches the Claudie convention.
- **nodepool/node.tpl.** Per nodepool: verda_ssh_key. Per node: optional verda_volume on workers with StorageDiskSize > 0, verda_startup_script with root SSH plus the standard custom-port reconfig plus iptables firewall plus optional /opt/claudie/data mount, and verda_instance with the existing_volumes wiring when applicable.

## Workaround for upstream provider bug

The terraform-provider-verda verda_instance.Create returns before Verda assigns the public IP, so verda_instance.<n>.ip is null in stored state. The template adds a time_sleep, an OAuth POST via data.http, and a re-fetch of GET /v1/instances/<id> after the wait. The block is clearly marked TEMPORARY and removable once upstream patches Create to call its existing waitForInstanceIP helper. An issue against verda-cloud/terraform-provider-verda will track the fix.

## Output contract

Output emits [ip, port] per node, picking the polled IP and the local SSH port. Claudie's parseNodeOutput already handles that shape.

## Validation

Three live-Verda scenarios passed end to end on a kind-hosted Claudie:

- Single-location FIN-01, 1 ctrl + 1 cmpt + Longhorn PVC.
- Multi-cloud Verda + AWS, 3 ctrl on Verda, 3 cmpt on AWS, WireGuard mesh across clouds.
- Autoscaling FIN-03, scale-up 1 to 3 nodes in 10s decision + 10 min pipeline, scale-down 3 to 1 after default 10 min cooldown.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added networking and firewall configuration capabilities for cluster infrastructure
  * Enhanced nodepool and node provisioning to improve cluster infrastructure management
  * Added provider configuration support to streamline infrastructure deployment

<!-- end of auto-generated comment: release notes by coderabbit.ai -->