### PR TITLE
feat: add OVH provider templates

### DIFF
--- a/templates/terraformer/ovh/dns/dns.tpl
+++ b/templates/terraformer/ovh/dns/dns.tpl
@@ -4,11 +4,7 @@
 {{- $clusterID         := printf "%s-%s" .Data.ClusterName .Data.ClusterHash }}
 
 provider "ovh" {
-{{- if .Data.Provider.GetOvh.Endpoint }}
-  endpoint      = "{{ .Data.Provider.GetOvh.Endpoint }}"
-{{- else }}
-  endpoint      = "ovh-eu"
-{{- end }}
+  endpoint      = "{{ .Data.Provider.GetOvh.Endpoint | default "ovh-eu" }}"
   client_id     = "{{ .Data.Provider.GetOvh.ClientId }}"
   client_secret = file("{{ $specName }}")
   alias         = "dns_{{ $resourceSuffix }}"

--- a/templates/terraformer/ovh/dns/dns.tpl
+++ b/templates/terraformer/ovh/dns/dns.tpl
@@ -1,0 +1,35 @@
+{{- $specName          := .Data.Provider.SpecName }}
+{{- $uniqueFingerPrint := .Fingerprint }}
+{{- $resourceSuffix    := printf "%s_%s" $specName $uniqueFingerPrint }}
+{{- $clusterID         := printf "%s-%s" .Data.ClusterName .Data.ClusterHash }}
+
+provider "ovh" {
+{{- if .Data.Provider.GetOvh.Endpoint }}
+  endpoint      = "{{ .Data.Provider.GetOvh.Endpoint }}"
+{{- else }}
+  endpoint      = "ovh-eu"
+{{- end }}
+  client_id     = "{{ .Data.Provider.GetOvh.ClientId }}"
+  client_secret = file("{{ $specName }}")
+  alias         = "dns_{{ $resourceSuffix }}"
+}
+
+{{ range $ip := .Data.RecordData.IP }}
+
+    {{- $escapedIPv4 := replaceAll $ip.V4 "." "_"}}
+    {{- $recordResourceName := printf "record_%s_%s" $escapedIPv4 $resourceSuffix }}
+
+    resource "ovh_domain_zone_record" "{{ $recordResourceName }}" {
+      provider  = ovh.dns_{{ $resourceSuffix }}
+      zone      = "{{ $.Data.DNSZone }}"
+      subdomain = "{{ $.Data.Hostname }}"
+      fieldtype = "A"
+      target    = "{{ $ip.V4 }}"
+      ttl       = 60
+    }
+
+{{- end }}
+
+output "{{ $clusterID }}_{{ $resourceSuffix }}" {
+  value = { "{{ $clusterID }}-endpoint" = format("%s.%s", "{{ .Data.Hostname }}", "{{ .Data.DNSZone }}")}
+}

--- a/templates/terraformer/ovh/dns/dns_alternative_names.tpl
+++ b/templates/terraformer/ovh/dns/dns_alternative_names.tpl
@@ -12,7 +12,7 @@
         zone      = "{{ $.Data.DNSZone }}"
         subdomain = "{{ $alternativeName }}"
         fieldtype = "CNAME"
-        target    = "{{ $.Data.Hostname }}.{{ $.Data.DNSZone }}."
+        target    = "{{ $.Data.Hostname }}.{{ $.Data.DNSZone }}"
         ttl       = 60
     }
 

--- a/templates/terraformer/ovh/dns/dns_alternative_names.tpl
+++ b/templates/terraformer/ovh/dns/dns_alternative_names.tpl
@@ -1,0 +1,24 @@
+{{- $specName          := .Data.Provider.SpecName }}
+{{- $uniqueFingerPrint := .Fingerprint }}
+{{- $resourceSuffix    := printf "%s_%s" $specName $uniqueFingerPrint }}
+{{- $clusterID         := printf "%s-%s" .Data.ClusterName .Data.ClusterHash }}
+
+{{- if hasExtension .Data "AlternativeNamesExtension" }}
+	{{- range $_, $alternativeName := .Data.AlternativeNamesExtension.Names }}
+    {{- $recordResourceName := printf "record_%s_%s" $alternativeName $resourceSuffix }}
+
+    resource "ovh_domain_zone_record" "{{ $recordResourceName }}" {
+        provider  = ovh.dns_{{ $resourceSuffix }}
+        zone      = "{{ $.Data.DNSZone }}"
+        subdomain = "{{ $alternativeName }}"
+        fieldtype = "CNAME"
+        target    = "{{ $.Data.Hostname }}.{{ $.Data.DNSZone }}."
+        ttl       = 60
+    }
+
+	output "{{ $clusterID }}_{{ $alternativeName }}_{{ $resourceSuffix }}" {
+	  value = { "{{ $clusterID }}-{{ $alternativeName }}-endpoint" = format("%s.%s", "{{ $alternativeName }}", "{{ $.Data.DNSZone }}")}
+	}
+
+	{{- end }}
+{{- end }}

--- a/templates/terraformer/ovh/networking/networking.tpl
+++ b/templates/terraformer/ovh/networking/networking.tpl
@@ -79,8 +79,10 @@ iptables -P INPUT DROP
 ip6tables -A INPUT -i lo -j ACCEPT
 ip6tables -P INPUT DROP
 ip6tables -P FORWARD DROP
-# Persist rules across reboots
+# Persist rules across reboots (both IPv4 and IPv6, so the default-drop posture survives reboots)
 DEBIAN_FRONTEND=noninteractive apt-get install -y -qq iptables-persistent > /dev/null 2>&1 || true
-iptables-save > /etc/iptables/rules.v4
+mkdir -p /etc/iptables
+iptables-save  > /etc/iptables/rules.v4
+ip6tables-save > /etc/iptables/rules.v6
 FWSCRIPT
 }

--- a/templates/terraformer/ovh/networking/networking.tpl
+++ b/templates/terraformer/ovh/networking/networking.tpl
@@ -1,0 +1,55 @@
+{{- $clusterName           := .Data.ClusterData.ClusterName}}
+{{- $clusterHash           := .Data.ClusterData.ClusterHash}}
+{{- $specName              := .Data.Provider.SpecName }}
+{{- $uniqueFingerPrint     := .Fingerprint }}
+{{- $isKubernetesCluster   := eq .Data.ClusterData.ClusterType "K8s" }}
+{{- $isLoadbalancerCluster := eq .Data.ClusterData.ClusterType "LB" }}
+{{- $LoadBalancerRoles     := .Data.LBData.Roles }}
+{{- $K8sHasAPIServer       := .Data.K8sData.HasAPIServer }}
+{{- $resourceSuffix        := printf "%s_%s" $specName $uniqueFingerPrint }}
+
+# The OVH OpenTofu provider has no cloud-level security group or firewall resources.
+# OVH Public Cloud security groups live in the OpenStack layer; to keep this provider
+# self-contained we configure host-level iptables instead (same approach as CloudRift).
+# KubeOne disables UFW during node provisioning but leaves iptables INPUT rules intact.
+# This template emits the firewall script as a Terraform local so that
+# nodepool/node.tpl can reference it inside the instance's user_data.
+
+locals {
+  claudie_ssh_port_{{ $resourceSuffix }} = 22522
+  ovh_firewall_script_{{ $resourceSuffix }} = <<-FWSCRIPT
+# Allow established connections and loopback
+iptables -A INPUT -m state --state ESTABLISHED,RELATED -j ACCEPT
+iptables -A INPUT -i lo -j ACCEPT
+# Allow SSH
+iptables -A INPUT -p tcp --dport ${local.claudie_ssh_port_{{ $resourceSuffix }}} -j ACCEPT
+# Allow WireGuard
+iptables -A INPUT -p udp --dport 51820 -j ACCEPT
+{{- if $isKubernetesCluster }}
+{{- if $K8sHasAPIServer }}
+# Allow K8s API server
+iptables -A INPUT -p tcp --dport 6443 -j ACCEPT
+{{- end }}
+# Allow kubelet API
+iptables -A INPUT -p tcp --dport 10250 -j ACCEPT
+{{- end }}
+{{- if $isLoadbalancerCluster }}
+  {{- range $role := $LoadBalancerRoles }}
+iptables -A INPUT -p {{ lower $role.Protocol }} --dport {{ $role.Port }} -j ACCEPT
+  {{- end }}
+{{- end }}
+# Allow ICMP
+iptables -A INPUT -p icmp -j ACCEPT
+# Allow all traffic on WireGuard tunnel interface
+iptables -A INPUT -i wg0 -j ACCEPT
+# Set default policy to drop everything else
+iptables -P INPUT DROP
+# Block IPv6 traffic but allow loopback (kube-apiserver uses [::1]:6443 internally)
+ip6tables -A INPUT -i lo -j ACCEPT
+ip6tables -P INPUT DROP
+ip6tables -P FORWARD DROP
+# Persist rules across reboots
+DEBIAN_FRONTEND=noninteractive apt-get install -y -qq iptables-persistent > /dev/null 2>&1 || true
+iptables-save > /etc/iptables/rules.v4
+FWSCRIPT
+}

--- a/templates/terraformer/ovh/networking/networking.tpl
+++ b/templates/terraformer/ovh/networking/networking.tpl
@@ -17,6 +17,37 @@
 
 locals {
   claudie_ssh_port_{{ $resourceSuffix }} = 22522
+
+  # Cloud-init bootstrap shared by every OVH instance in this cluster: enable
+  # root SSH from the ubuntu/debian default user and move sshd to the Claudie
+  # port via a systemd socket override.
+  ovh_bootstrap_script_{{ $resourceSuffix }} = <<-BOOTSCRIPT
+# Enable root SSH access
+mkdir -p /root/.ssh
+chmod 700 /root/.ssh
+if [ -f /home/ubuntu/.ssh/authorized_keys ]; then
+    cp /home/ubuntu/.ssh/authorized_keys /root/.ssh/authorized_keys
+    chmod 600 /root/.ssh/authorized_keys
+fi
+if [ -f /home/debian/.ssh/authorized_keys ]; then
+    cp /home/debian/.ssh/authorized_keys /root/.ssh/authorized_keys
+    chmod 600 /root/.ssh/authorized_keys
+fi
+sed -i 's/^#\?PermitRootLogin.*/PermitRootLogin without-password/' /etc/ssh/sshd_config
+sed -i 's/^#\?PubkeyAuthentication.*/PubkeyAuthentication yes/' /etc/ssh/sshd_config
+
+# Configure SSH port
+echo "Port ${local.claudie_ssh_port_{{ $resourceSuffix }}}" >> /etc/ssh/sshd_config
+mkdir -p /etc/systemd/system/ssh.socket.d
+cat <<SSHEOF > /etc/systemd/system/ssh.socket.d/override.conf
+[Socket]
+ListenStream=
+ListenStream=0.0.0.0:${local.claudie_ssh_port_{{ $resourceSuffix }}}
+SSHEOF
+systemctl daemon-reload
+systemctl restart ssh.socket 2>/dev/null || systemctl restart ssh 2>/dev/null || systemctl restart sshd 2>/dev/null
+BOOTSCRIPT
+
   ovh_firewall_script_{{ $resourceSuffix }} = <<-FWSCRIPT
 # Allow established connections and loopback
 iptables -A INPUT -m state --state ESTABLISHED,RELATED -j ACCEPT

--- a/templates/terraformer/ovh/networking/networking.tpl
+++ b/templates/terraformer/ovh/networking/networking.tpl
@@ -61,8 +61,6 @@ iptables -A INPUT -p udp --dport 51820 -j ACCEPT
 # Allow K8s API server
 iptables -A INPUT -p tcp --dport 6443 -j ACCEPT
 {{- end }}
-# Allow kubelet API
-iptables -A INPUT -p tcp --dport 10250 -j ACCEPT
 {{- end }}
 {{- if $isLoadbalancerCluster }}
   {{- range $role := $LoadBalancerRoles }}

--- a/templates/terraformer/ovh/nodepool/node.tpl
+++ b/templates/terraformer/ovh/nodepool/node.tpl
@@ -1,0 +1,168 @@
+{{- $clusterName           := .Data.ClusterData.ClusterName}}
+{{- $clusterHash           := .Data.ClusterData.ClusterHash}}
+{{- $uniqueFingerPrint     := .Fingerprint }}
+{{- $isKubernetesCluster   := eq .Data.ClusterData.ClusterType "K8s" }}
+{{- $isLoadbalancerCluster := eq .Data.ClusterData.ClusterType "LB" }}
+
+
+{{- range $nodepool := .Data.NodePools }}
+
+{{- $specName       := $nodepool.Details.Provider.SpecName }}
+{{- $serviceName    := $nodepool.Details.Provider.GetOvh.ServiceName }}
+{{- $resourceSuffix := printf "%s_%s" $specName $uniqueFingerPrint }}
+
+{{- $sshKeyResourceName := printf "key_%s_%s" $nodepool.Name $resourceSuffix }}
+{{- $sshKeyName         := printf "key-%s-%s-%s" $nodepool.Name $clusterHash $specName }}
+
+    data "ovh_cloud_project_image" "image_{{ $resourceSuffix }}_{{ $nodepool.Name }}" {
+      provider     = ovh.nodepool_{{ $resourceSuffix }}
+      service_name = "{{ $serviceName }}"
+      region       = "{{ $nodepool.Details.Region }}"
+      name         = "{{ $nodepool.Details.Image }}"
+    }
+
+    data "ovh_cloud_project_flavor" "flavor_{{ $resourceSuffix }}_{{ $nodepool.Name }}" {
+      provider     = ovh.nodepool_{{ $resourceSuffix }}
+      service_name = "{{ $serviceName }}"
+      region       = "{{ $nodepool.Details.Region }}"
+      name         = "{{ $nodepool.Details.ServerType }}"
+    }
+
+    resource "ovh_cloud_project_sshkey" "{{ $sshKeyResourceName }}" {
+      provider     = ovh.nodepool_{{ $resourceSuffix }}
+      service_name = "{{ $serviceName }}"
+      name         = "{{ $sshKeyName }}"
+      public_key   = file("./{{ $nodepool.Name }}")
+    }
+
+    {{- range $node := $nodepool.Nodes }}
+
+        {{- $serverResourceName           := printf "%s_%s" $node.Name $resourceSuffix }}
+        {{- $isWorkerNodeWithDiskAttached := and (not $nodepool.IsControl) (gt $nodepool.Details.StorageDiskSize 0) }}
+        {{- $volumeResourceName           := printf "%s_%s_volume" $node.Name $resourceSuffix }}
+        {{- $volumeAttachResourceName     := printf "%s_att" $volumeResourceName }}
+
+        resource "ovh_cloud_project_instance" "{{ $serverResourceName }}" {
+          provider       = ovh.nodepool_{{ $resourceSuffix }}
+          service_name   = "{{ $serviceName }}"
+          region         = "{{ $nodepool.Details.Region }}"
+          billing_period = "hourly"
+          name           = "{{ $node.Name }}"
+
+          boot_from {
+            image_id = data.ovh_cloud_project_image.image_{{ $resourceSuffix }}_{{ $nodepool.Name }}.id
+          }
+
+          flavor {
+            flavor_id = data.ovh_cloud_project_flavor.flavor_{{ $resourceSuffix }}_{{ $nodepool.Name }}.id
+          }
+
+          ssh_key {
+            name = ovh_cloud_project_sshkey.{{ $sshKeyResourceName }}.name
+          }
+
+          network {
+            public = true
+          }
+
+          user_data = <<-EOF
+#!/bin/bash
+# Enable root SSH access
+mkdir -p /root/.ssh
+chmod 700 /root/.ssh
+if [ -f /home/ubuntu/.ssh/authorized_keys ]; then
+    cp /home/ubuntu/.ssh/authorized_keys /root/.ssh/authorized_keys
+    chmod 600 /root/.ssh/authorized_keys
+fi
+if [ -f /home/debian/.ssh/authorized_keys ]; then
+    cp /home/debian/.ssh/authorized_keys /root/.ssh/authorized_keys
+    chmod 600 /root/.ssh/authorized_keys
+fi
+sed -i 's/^#\?PermitRootLogin.*/PermitRootLogin without-password/' /etc/ssh/sshd_config
+sed -i 's/^#\?PubkeyAuthentication.*/PubkeyAuthentication yes/' /etc/ssh/sshd_config
+
+# Configure SSH port
+echo "Port ${local.claudie_ssh_port_{{ $resourceSuffix }}}" >> /etc/ssh/sshd_config
+mkdir -p /etc/systemd/system/ssh.socket.d
+cat <<SSHEOF > /etc/systemd/system/ssh.socket.d/override.conf
+[Socket]
+ListenStream=
+ListenStream=0.0.0.0:${local.claudie_ssh_port_{{ $resourceSuffix }}}
+SSHEOF
+systemctl daemon-reload
+systemctl restart ssh.socket 2>/dev/null || systemctl restart ssh 2>/dev/null || systemctl restart sshd 2>/dev/null
+
+# Configure iptables firewall (not UFW, KubeOne disables UFW)
+${local.ovh_firewall_script_{{ $resourceSuffix }}}
+
+{{- if $isKubernetesCluster }}
+# Create longhorn volume directory
+mkdir -p /opt/claudie/data
+
+    {{- if $isWorkerNodeWithDiskAttached }}
+
+# Mount the Cinder volume.
+# OVH Public Cloud volumes appear under /dev/disk/by-id/ with a virtio- prefix
+# whose serial matches the first 20 characters of the volume UUID (no dashes).
+VOL_ID="${ovh_cloud_project_volume.{{ $volumeResourceName }}.id}"
+SERIAL=$(echo "$VOL_ID" | tr -d '-' | cut -c1-20)
+for i in $(seq 1 60); do
+    if [ -e "/dev/disk/by-id/virtio-$SERIAL" ]; then
+        break
+    fi
+    sleep 1
+done
+disk=$(readlink -f "/dev/disk/by-id/virtio-$SERIAL" 2>/dev/null || true)
+if [ -n "$disk" ] && [ -b "$disk" ]; then
+    if ! blkid "$disk" | grep -q 'TYPE="xfs"'; then
+        mkfs.xfs "$disk"
+    fi
+    if ! grep -qs "$disk" /proc/mounts; then
+        mount "$disk" /opt/claudie/data
+        echo "$disk /opt/claudie/data xfs defaults 0 0" >> /etc/fstab
+    fi
+fi
+    {{- end }}
+{{- end }}
+EOF
+        }
+
+        {{- if $isKubernetesCluster }}
+            {{- if $isWorkerNodeWithDiskAttached }}
+
+            {{- $volumeName := printf "%sd" $node.Name }}
+
+            resource "ovh_cloud_project_volume" "{{ $volumeResourceName }}" {
+              provider     = ovh.nodepool_{{ $resourceSuffix }}
+              service_name = "{{ $serviceName }}"
+              region_name  = "{{ $nodepool.Details.Region }}"
+              name         = "{{ $volumeName }}"
+              size         = {{ $nodepool.Details.StorageDiskSize }}
+              type         = "classic"
+            }
+
+            resource "ovh_cloud_project_volume_attached" "{{ $volumeAttachResourceName }}" {
+              provider     = ovh.nodepool_{{ $resourceSuffix }}
+              service_name = "{{ $serviceName }}"
+              region_name  = "{{ $nodepool.Details.Region }}"
+              volume_id    = ovh_cloud_project_volume.{{ $volumeResourceName }}.id
+              instance_id  = ovh_cloud_project_instance.{{ $serverResourceName }}.id
+            }
+
+            {{- end }}
+        {{- end }}
+
+    {{- end }}
+
+output "{{ $nodepool.Name }}_{{ $specName }}_{{ $uniqueFingerPrint }}" {
+  value = {
+    {{- range $node := $nodepool.Nodes }}
+        {{- $serverResourceName := printf "%s_%s" $node.Name $resourceSuffix }}
+        "{{ $node.Name }}" = [
+          [for addr in ovh_cloud_project_instance.{{ $serverResourceName }}.addresses : addr.ip if addr.version == 4 && addr.type == "public"][0],
+          tostring(local.claudie_ssh_port_{{ $resourceSuffix }})
+        ]
+    {{- end }}
+  }
+}
+{{- end }}

--- a/templates/terraformer/ovh/nodepool/node.tpl
+++ b/templates/terraformer/ovh/nodepool/node.tpl
@@ -35,6 +35,9 @@
           provider       = ovh.nodepool_{{ $resourceSuffix }}
           service_name   = "{{ $serviceName }}"
           region         = "{{ $nodepool.Details.Region }}"
+{{- if $nodepool.Details.Zone }}
+          availability_zone = "{{ $nodepool.Details.Zone }}"
+{{- end }}
           billing_period = "hourly"
           name           = "{{ $node.Name }}"
 

--- a/templates/terraformer/ovh/nodepool/node.tpl
+++ b/templates/terraformer/ovh/nodepool/node.tpl
@@ -14,12 +14,6 @@
 {{- $sshKeyResourceName := printf "key_%s_%s" $nodepool.Name $resourceSuffix }}
 {{- $sshKeyName         := printf "key-%s-%s-%s" $nodepool.Name $clusterHash $specName }}
 
-    # The OVH provider v2.x has no by-name data source for images or flavors.
-    # The InputManifest's `image` and `serverType` fields therefore must be
-    # OVH UUIDs (image_id and flavor_id), not human-readable names. Look them
-    # up once via the OVH CLI or API for your project and region:
-    #   ovhcloud cloud project flavor list --service-name <project-id> --region <region>
-    #   ovhcloud cloud project image list  --service-name <project-id> --region <region>
     resource "ovh_cloud_project_ssh_key" "{{ $sshKeyResourceName }}" {
       provider     = ovh.nodepool_{{ $resourceSuffix }}
       service_name = "{{ $serviceName }}"
@@ -59,39 +53,15 @@
 
           user_data = <<-EOF
 #!/bin/bash
-# Enable root SSH access
-mkdir -p /root/.ssh
-chmod 700 /root/.ssh
-if [ -f /home/ubuntu/.ssh/authorized_keys ]; then
-    cp /home/ubuntu/.ssh/authorized_keys /root/.ssh/authorized_keys
-    chmod 600 /root/.ssh/authorized_keys
-fi
-if [ -f /home/debian/.ssh/authorized_keys ]; then
-    cp /home/debian/.ssh/authorized_keys /root/.ssh/authorized_keys
-    chmod 600 /root/.ssh/authorized_keys
-fi
-sed -i 's/^#\?PermitRootLogin.*/PermitRootLogin without-password/' /etc/ssh/sshd_config
-sed -i 's/^#\?PubkeyAuthentication.*/PubkeyAuthentication yes/' /etc/ssh/sshd_config
-
-# Configure SSH port
-echo "Port ${local.claudie_ssh_port_{{ $resourceSuffix }}}" >> /etc/ssh/sshd_config
-mkdir -p /etc/systemd/system/ssh.socket.d
-cat <<SSHEOF > /etc/systemd/system/ssh.socket.d/override.conf
-[Socket]
-ListenStream=
-ListenStream=0.0.0.0:${local.claudie_ssh_port_{{ $resourceSuffix }}}
-SSHEOF
-systemctl daemon-reload
-systemctl restart ssh.socket 2>/dev/null || systemctl restart ssh 2>/dev/null || systemctl restart sshd 2>/dev/null
+${local.ovh_bootstrap_script_{{ $resourceSuffix }}}
 
 # Configure iptables firewall (not UFW, KubeOne disables UFW)
 ${local.ovh_firewall_script_{{ $resourceSuffix }}}
 
 {{- if $isKubernetesCluster }}
-# Create longhorn volume directory on the OS disk.
-# Note: v1 of the OVH provider integration does not attach a separate Cinder
-# volume (the OVH provider exposes no Terraform resource to attach an existing
-# volume to a running instance). Storage lives on the OS disk for now.
+# Longhorn data directory on the OS disk. storageDiskSize is currently
+# ignored on OVH: the upstream Terraform provider exposes no resource to
+# attach a separate volume to an instance, so data shares the OS disk.
 mkdir -p /opt/claudie/data
 {{- end }}
 EOF

--- a/templates/terraformer/ovh/nodepool/node.tpl
+++ b/templates/terraformer/ovh/nodepool/node.tpl
@@ -14,21 +14,13 @@
 {{- $sshKeyResourceName := printf "key_%s_%s" $nodepool.Name $resourceSuffix }}
 {{- $sshKeyName         := printf "key-%s-%s-%s" $nodepool.Name $clusterHash $specName }}
 
-    data "ovh_cloud_project_image" "image_{{ $resourceSuffix }}_{{ $nodepool.Name }}" {
-      provider     = ovh.nodepool_{{ $resourceSuffix }}
-      service_name = "{{ $serviceName }}"
-      region       = "{{ $nodepool.Details.Region }}"
-      name         = "{{ $nodepool.Details.Image }}"
-    }
-
-    data "ovh_cloud_project_flavor" "flavor_{{ $resourceSuffix }}_{{ $nodepool.Name }}" {
-      provider     = ovh.nodepool_{{ $resourceSuffix }}
-      service_name = "{{ $serviceName }}"
-      region       = "{{ $nodepool.Details.Region }}"
-      name         = "{{ $nodepool.Details.ServerType }}"
-    }
-
-    resource "ovh_cloud_project_sshkey" "{{ $sshKeyResourceName }}" {
+    # The OVH provider v2.x has no by-name data source for images or flavors.
+    # The InputManifest's `image` and `serverType` fields therefore must be
+    # OVH UUIDs (image_id and flavor_id), not human-readable names. Look them
+    # up once via the OVH CLI or API for your project and region:
+    #   ovhcloud cloud project flavor list --service-name <project-id> --region <region>
+    #   ovhcloud cloud project image list  --service-name <project-id> --region <region>
+    resource "ovh_cloud_project_ssh_key" "{{ $sshKeyResourceName }}" {
       provider     = ovh.nodepool_{{ $resourceSuffix }}
       service_name = "{{ $serviceName }}"
       name         = "{{ $sshKeyName }}"
@@ -37,10 +29,7 @@
 
     {{- range $node := $nodepool.Nodes }}
 
-        {{- $serverResourceName           := printf "%s_%s" $node.Name $resourceSuffix }}
-        {{- $isWorkerNodeWithDiskAttached := and (not $nodepool.IsControl) (gt $nodepool.Details.StorageDiskSize 0) }}
-        {{- $volumeResourceName           := printf "%s_%s_volume" $node.Name $resourceSuffix }}
-        {{- $volumeAttachResourceName     := printf "%s_att" $volumeResourceName }}
+        {{- $serverResourceName := printf "%s_%s" $node.Name $resourceSuffix }}
 
         resource "ovh_cloud_project_instance" "{{ $serverResourceName }}" {
           provider       = ovh.nodepool_{{ $resourceSuffix }}
@@ -50,15 +39,15 @@
           name           = "{{ $node.Name }}"
 
           boot_from {
-            image_id = data.ovh_cloud_project_image.image_{{ $resourceSuffix }}_{{ $nodepool.Name }}.id
+            image_id = "{{ $nodepool.Details.Image }}"
           }
 
           flavor {
-            flavor_id = data.ovh_cloud_project_flavor.flavor_{{ $resourceSuffix }}_{{ $nodepool.Name }}.id
+            flavor_id = "{{ $nodepool.Details.ServerType }}"
           }
 
           ssh_key {
-            name = ovh_cloud_project_sshkey.{{ $sshKeyResourceName }}.name
+            name = ovh_cloud_project_ssh_key.{{ $sshKeyResourceName }}.name
           }
 
           network {
@@ -96,61 +85,14 @@ systemctl restart ssh.socket 2>/dev/null || systemctl restart ssh 2>/dev/null ||
 ${local.ovh_firewall_script_{{ $resourceSuffix }}}
 
 {{- if $isKubernetesCluster }}
-# Create longhorn volume directory
+# Create longhorn volume directory on the OS disk.
+# Note: v1 of the OVH provider integration does not attach a separate Cinder
+# volume (the OVH provider exposes no Terraform resource to attach an existing
+# volume to a running instance). Storage lives on the OS disk for now.
 mkdir -p /opt/claudie/data
-
-    {{- if $isWorkerNodeWithDiskAttached }}
-
-# Mount the Cinder volume.
-# OVH Public Cloud volumes appear under /dev/disk/by-id/ with a virtio- prefix
-# whose serial matches the first 20 characters of the volume UUID (no dashes).
-VOL_ID="${ovh_cloud_project_volume.{{ $volumeResourceName }}.id}"
-SERIAL=$(echo "$VOL_ID" | tr -d '-' | cut -c1-20)
-for i in $(seq 1 60); do
-    if [ -e "/dev/disk/by-id/virtio-$SERIAL" ]; then
-        break
-    fi
-    sleep 1
-done
-disk=$(readlink -f "/dev/disk/by-id/virtio-$SERIAL" 2>/dev/null || true)
-if [ -n "$disk" ] && [ -b "$disk" ]; then
-    if ! blkid "$disk" | grep -q 'TYPE="xfs"'; then
-        mkfs.xfs "$disk"
-    fi
-    if ! grep -qs "$disk" /proc/mounts; then
-        mount "$disk" /opt/claudie/data
-        echo "$disk /opt/claudie/data xfs defaults 0 0" >> /etc/fstab
-    fi
-fi
-    {{- end }}
 {{- end }}
 EOF
         }
-
-        {{- if $isKubernetesCluster }}
-            {{- if $isWorkerNodeWithDiskAttached }}
-
-            {{- $volumeName := printf "%sd" $node.Name }}
-
-            resource "ovh_cloud_project_volume" "{{ $volumeResourceName }}" {
-              provider     = ovh.nodepool_{{ $resourceSuffix }}
-              service_name = "{{ $serviceName }}"
-              region_name  = "{{ $nodepool.Details.Region }}"
-              name         = "{{ $volumeName }}"
-              size         = {{ $nodepool.Details.StorageDiskSize }}
-              type         = "classic"
-            }
-
-            resource "ovh_cloud_project_volume_attached" "{{ $volumeAttachResourceName }}" {
-              provider     = ovh.nodepool_{{ $resourceSuffix }}
-              service_name = "{{ $serviceName }}"
-              region_name  = "{{ $nodepool.Details.Region }}"
-              volume_id    = ovh_cloud_project_volume.{{ $volumeResourceName }}.id
-              instance_id  = ovh_cloud_project_instance.{{ $serverResourceName }}.id
-            }
-
-            {{- end }}
-        {{- end }}
 
     {{- end }}
 

--- a/templates/terraformer/ovh/nodepool/node.tpl
+++ b/templates/terraformer/ovh/nodepool/node.tpl
@@ -104,7 +104,7 @@ output "{{ $nodepool.Name }}_{{ $specName }}_{{ $uniqueFingerPrint }}" {
     {{- range $node := $nodepool.Nodes }}
         {{- $serverResourceName := printf "%s_%s" $node.Name $resourceSuffix }}
         "{{ $node.Name }}" = [
-          [for addr in ovh_cloud_project_instance.{{ $serverResourceName }}.addresses : addr.ip if addr.version == 4 && addr.type == "public"][0],
+          [for addr in ovh_cloud_project_instance.{{ $serverResourceName }}.addresses : addr.ip if addr.version == 4][0],
           tostring(local.claudie_ssh_port_{{ $resourceSuffix }})
         ]
     {{- end }}

--- a/templates/terraformer/ovh/provider/provider.tpl
+++ b/templates/terraformer/ovh/provider/provider.tpl
@@ -1,0 +1,14 @@
+{{- $specName          := .Data.Provider.SpecName }}
+{{- $uniqueFingerPrint := .Fingerprint }}
+{{- $resourceSuffix    := printf "%s_%s" $specName $uniqueFingerPrint }}
+
+provider "ovh" {
+{{- if .Data.Provider.GetOvh.Endpoint }}
+  endpoint      = "{{ .Data.Provider.GetOvh.Endpoint }}"
+{{- else }}
+  endpoint      = "ovh-eu"
+{{- end }}
+  client_id     = "{{ .Data.Provider.GetOvh.ClientId }}"
+  client_secret = file("{{ $specName }}")
+  alias         = "nodepool_{{ $resourceSuffix }}"
+}

--- a/templates/terraformer/ovh/provider/provider.tpl
+++ b/templates/terraformer/ovh/provider/provider.tpl
@@ -3,11 +3,7 @@
 {{- $resourceSuffix    := printf "%s_%s" $specName $uniqueFingerPrint }}
 
 provider "ovh" {
-{{- if .Data.Provider.GetOvh.Endpoint }}
-  endpoint      = "{{ .Data.Provider.GetOvh.Endpoint }}"
-{{- else }}
-  endpoint      = "ovh-eu"
-{{- end }}
+  endpoint      = "{{ .Data.Provider.GetOvh.Endpoint | default "ovh-eu" }}"
   client_id     = "{{ .Data.Provider.GetOvh.ClientId }}"
   client_secret = file("{{ $specName }}")
   alias         = "nodepool_{{ $resourceSuffix }}"


### PR DESCRIPTION
Adds OVH provider templates for terraformer.

Covers compute (provider block, host-level iptables firewall, nodepool) and DNS (A records plus alternative names). Uses the native ovh/ovh terraform provider v2.13 with OAuth2 client_id/client_secret auth.

Companion to the OVH PR in berops/claudie.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added Terraform templates for OVH DNS management with IPv4 and CNAME record support
  * Added Terraform templates for OVH networking configuration including firewall rules and SSH access
  * Added Terraform templates for OVH nodepool provisioning with instance and SSH key management
  * Added OVH provider configuration template

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/berops/claudie-config/pull/35?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->