### PR TITLE
cloudrift: support shared-IP instances with port mapping

### DIFF
--- a/templates/terraformer/cloudrift/networking/networking.tpl
+++ b/templates/terraformer/cloudrift/networking/networking.tpl
@@ -31,8 +31,9 @@ iptables -A INPUT -p udp --dport 51820 -j ACCEPT
 {{- if $isKubernetesCluster }}
 # Allow K8s API server
 iptables -A INPUT -p tcp --dport 6443 -j ACCEPT
-# Allow kubelet API
-iptables -A INPUT -p tcp --dport 10250 -j ACCEPT
+# Kubelet API (10250) is intentionally NOT opened here: control-plane and
+# metrics-server reach the kubelet over the WireGuard mesh (node InternalIP is
+# the wg IP), which the "-i wg0 -j ACCEPT" rule below already permits.
 {{- end }}
 {{- if $isLoadbalancerCluster }}
   {{- range $role := $LoadBalancerRoles }}

--- a/templates/terraformer/cloudrift/networking/networking.tpl
+++ b/templates/terraformer/cloudrift/networking/networking.tpl
@@ -15,7 +15,11 @@
 # so that nodepool/node.tpl can reference it in startup_commands.
 
 locals {
-  claudie_ssh_port_{{ $resourceSuffix }} = 22522
+  # CloudRift's shared-IP NAT forwards the standard guest SSH port (22) to a
+  # random host port (exposed via port_mappings), so the in-VM sshd must listen
+  # on 22 for the forward to land. node.tpl keys the SSH-port output, the sshd
+  # config, and the firewall rule off this local.
+  claudie_ssh_port_{{ $resourceSuffix }} = 22
   cloudrift_firewall_script_{{ $resourceSuffix }} = <<-FWSCRIPT
 # Allow established connections and loopback
 iptables -A INPUT -m state --state ESTABLISHED,RELATED -j ACCEPT

--- a/templates/terraformer/cloudrift/nodepool/node.tpl
+++ b/templates/terraformer/cloudrift/nodepool/node.tpl
@@ -104,4 +104,16 @@ output "{{ $nodepool.Name }}_{{ $specName }}_{{ $uniqueFingerPrint }}" {
     {{- end }}
   }
 }
+
+# DEBUG (test-only): raw port_mappings per node so we can see exactly which
+# guest ports CloudRift forwards (e.g. whether WireGuard 51820 is mapped).
+# Terraformer ignores this output; it only reads the nodepool-keyed output above.
+output "debug_portmappings_{{ $nodepool.Name }}_{{ $specName }}_{{ $uniqueFingerPrint }}" {
+  value = {
+    {{- range $node := $nodepool.Nodes }}
+        {{- $serverResourceName := printf "%s_%s" $node.Name $resourceSuffix }}
+        "{{ $node.Name }}" = cloudrift_virtual_machine.{{ $serverResourceName }}.port_mappings
+    {{- end }}
+  }
+}
 {{- end }}

--- a/templates/terraformer/cloudrift/nodepool/node.tpl
+++ b/templates/terraformer/cloudrift/nodepool/node.tpl
@@ -108,16 +108,4 @@ output "{{ $nodepool.Name }}_{{ $specName }}_{{ $uniqueFingerPrint }}" {
     {{- end }}
   }
 }
-
-# DEBUG (test-only): raw port_mappings per node so we can see exactly which
-# guest ports CloudRift forwards (e.g. whether WireGuard 51820 is mapped).
-# Terraformer ignores this output; it only reads the nodepool-keyed output above.
-output "debug_portmappings_{{ $nodepool.Name }}_{{ $specName }}_{{ $uniqueFingerPrint }}" {
-  value = {
-    {{- range $node := $nodepool.Nodes }}
-        {{- $serverResourceName := printf "%s_%s" $node.Name $resourceSuffix }}
-        "{{ $node.Name }}" = cloudrift_virtual_machine.{{ $serverResourceName }}.port_mappings
-    {{- end }}
-  }
-}
 {{- end }}

--- a/templates/terraformer/cloudrift/nodepool/node.tpl
+++ b/templates/terraformer/cloudrift/nodepool/node.tpl
@@ -84,11 +84,23 @@ SCRIPT
 
     {{- end }}
 
+# Output: [public_ip, ssh_port, wireguard_port] per node.
+#
+# For dedicated-IP instances port_mappings is null, so each port falls back to
+# the in-VM listen port (claudie_ssh_port / 51820) reached directly on the public IP.
+#
+# For shared-IP instances CloudRift returns port_mappings ([{host_port, guest_port}]),
+# and we emit the host_port that forwards to the in-VM SSH port and to WireGuard 51820.
+# The guest_port we match on is the port the service actually listens on inside the VM.
 output "{{ $nodepool.Name }}_{{ $specName }}_{{ $uniqueFingerPrint }}" {
   value = {
     {{- range $node := $nodepool.Nodes }}
         {{- $serverResourceName := printf "%s_%s" $node.Name $resourceSuffix }}
-        "{{ $node.Name }}" = [cloudrift_virtual_machine.{{ $serverResourceName }}.public_ip, tostring(local.claudie_ssh_port_{{ $resourceSuffix }})]
+        "{{ $node.Name }}" = [
+          cloudrift_virtual_machine.{{ $serverResourceName }}.public_ip,
+          tostring(coalesce(one([for m in try(cloudrift_virtual_machine.{{ $serverResourceName }}.port_mappings, []) : m.host_port if m.guest_port == local.claudie_ssh_port_{{ $resourceSuffix }}]), local.claudie_ssh_port_{{ $resourceSuffix }})),
+          tostring(coalesce(one([for m in try(cloudrift_virtual_machine.{{ $serverResourceName }}.port_mappings, []) : m.host_port if m.guest_port == 51820]), 51820)),
+        ]
     {{- end }}
   }
 }

--- a/templates/terraformer/cloudrift/nodepool/node.tpl
+++ b/templates/terraformer/cloudrift/nodepool/node.tpl
@@ -86,20 +86,24 @@ SCRIPT
 
 # Output: [public_ip, ssh_port, wireguard_port] per node.
 #
-# For dedicated-IP instances port_mappings is null, so each port falls back to
-# the in-VM listen port (claudie_ssh_port / 51820) reached directly on the public IP.
+# CloudRift's port_mappings entries are {host_port, guest_port} where, despite the
+# names, host_port is the IN-VM service port (22, 80, 443, ...) and guest_port is
+# the externally reachable port on the SHARED public IP (e.g. 60002). So to reach
+# the VM's SSH (in-VM port = claudie_ssh_port) we connect to the public IP on the
+# matching guest_port. CloudRift forwards a fixed set of in-VM ports (22/80/443/
+# 8080/8443); WireGuard's 51820 is NOT forwarded, so it falls back to 51820 and the
+# node relies on initiating the tunnel outbound (PersistentKeepalive).
 #
-# For shared-IP instances CloudRift returns port_mappings ([{host_port, guest_port}]),
-# and we emit the host_port that forwards to the in-VM SSH port and to WireGuard 51820.
-# The guest_port we match on is the port the service actually listens on inside the VM.
+# Dedicated-IP instances have empty port_mappings, so both ports fall back to the
+# in-VM listen ports reached directly on the public IP.
 output "{{ $nodepool.Name }}_{{ $specName }}_{{ $uniqueFingerPrint }}" {
   value = {
     {{- range $node := $nodepool.Nodes }}
         {{- $serverResourceName := printf "%s_%s" $node.Name $resourceSuffix }}
         "{{ $node.Name }}" = [
           cloudrift_virtual_machine.{{ $serverResourceName }}.public_ip,
-          tostring(coalesce(one([for m in try(cloudrift_virtual_machine.{{ $serverResourceName }}.port_mappings, []) : m.host_port if m.guest_port == local.claudie_ssh_port_{{ $resourceSuffix }}]), local.claudie_ssh_port_{{ $resourceSuffix }})),
-          tostring(coalesce(one([for m in try(cloudrift_virtual_machine.{{ $serverResourceName }}.port_mappings, []) : m.host_port if m.guest_port == 51820]), 51820)),
+          tostring(coalesce(one([for m in try(cloudrift_virtual_machine.{{ $serverResourceName }}.port_mappings, []) : m.guest_port if m.host_port == local.claudie_ssh_port_{{ $resourceSuffix }}]), local.claudie_ssh_port_{{ $resourceSuffix }})),
+          tostring(coalesce(one([for m in try(cloudrift_virtual_machine.{{ $serverResourceName }}.port_mappings, []) : m.guest_port if m.host_port == 51820]), 51820)),
         ]
     {{- end }}
   }


### PR DESCRIPTION
CloudRift can place a VM behind a shared public IP and forward its in-VM ports to random ports on that IP.

The cloudrift nodepool template now reads each VM's port_mappings and outputs the externally reachable SSH and WireGuard ports per node, so Claudie connects on the mapped ports. SSH inside the VM moves to the standard port 22, which is what CloudRift forwards.

Dedicated-IP instances are unaffected: port_mappings is empty, so both ports fall back to the in-VM ports reached directly on the public IP.

Needs the matching per-node port support in berops/claudie and the with_public_ip option in berops/terraform-provider-cloudrift.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * SSH port configuration corrected to use standard port, ensuring proper alignment with shared-IP NAT behavior.

* **Features**
  * Node outputs now include WireGuard UDP port derived from port mappings, replacing fixed port fallback.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->