### PR TITLE
Render GCP Spot VM scheduling block

### DIFF
--- a/templates/terraformer/gcp/nodepool/node.tpl
+++ b/templates/terraformer/gcp/nodepool/node.tpl
@@ -39,18 +39,31 @@
           description   = "Managed by Claudie for cluster {{ $clusterName }}-{{ $clusterHash }}"
           allow_stopping_for_update = true
 
-          {{- /* GPU Guest Accelerator Configuration */}}
-          {{- if and $nodepool.Details.MachineSpec $nodepool.Details.MachineSpec.NvidiaGpuCount }}
-          {{- if gt $nodepool.Details.MachineSpec.NvidiaGpuCount 0 }}
+          {{- /* GPU + Spot scheduling. A single scheduling block must be emitted. */}}
+          {{- $hasGpu := false }}
+          {{- if $nodepool.Details.MachineSpec }}
+          {{-   if gt $nodepool.Details.MachineSpec.NvidiaGpuCount 0 }}
+          {{-     $hasGpu = true }}
+          {{-   end }}
+          {{- end }}
+
+          {{- if $hasGpu }}
           guest_accelerator {
             type  = "{{ $nodepool.Details.MachineSpec.NvidiaGpuType }}"
             count = {{ $nodepool.Details.MachineSpec.NvidiaGpuCount }}
           }
+          {{- end }}
 
+          {{- if or $hasGpu $nodepool.Details.Spot }}
           scheduling {
+          {{- if $nodepool.Details.Spot }}
+            provisioning_model          = "SPOT"
+            preemptible                 = true
+            automatic_restart           = false
+            instance_termination_action = "DELETE"
+          {{- end }}
             on_host_maintenance = "TERMINATE"
           }
-          {{- end }}
           {{- end }}
 
           network_interface {

--- a/templates/terraformer/gcp/nodepool/node.tpl
+++ b/templates/terraformer/gcp/nodepool/node.tpl
@@ -39,7 +39,10 @@
           description   = "Managed by Claudie for cluster {{ $clusterName }}-{{ $clusterHash }}"
           allow_stopping_for_update = true
 
-          {{- /* GPU + Spot scheduling. A single scheduling block must be emitted. */}}
+          {{- /* GPU + Spot scheduling: emit a single scheduling block. $hasGpu is
+                 built with nested ifs on purpose: Go template 'and' does not
+                 short-circuit, so 'and MachineSpec (gt ... 0)' would nil-deref
+                 when MachineSpec is unset. */}}
           {{- $hasGpu := false }}
           {{- if $nodepool.Details.MachineSpec }}
           {{-   if gt $nodepool.Details.MachineSpec.NvidiaGpuCount 0 }}


### PR DESCRIPTION
Emits a single `google_compute_instance` scheduling block driven by GPU and/or the new nodepool `spot` flag, replacing the GPU-only block. Spot nodes get `provisioning_model = SPOT`, `automatic_restart = false`, and `on_host_maintenance = TERMINATE`.

Pairs with the claudie `spot` field. See berops/claudie#2078.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Improvements**
  * Enhanced GPU detection and configuration handling for GCP nodepools.
  * Improved Spot instance scheduling with proper provisioning parameters.
  * GPU and Spot instances now work together with unified scheduling configuration, including automatic restart and termination behavior settings.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->