### PR TITLE
Render spot scheduling for AWS, Azure and OCI

### DIFF
--- a/templates/terraformer/aws/nodepool/node.tpl
+++ b/templates/terraformer/aws/nodepool/node.tpl
@@ -72,6 +72,16 @@ resource "aws_key_pair" "{{ $keypairResourceName }}" {
           subnet_id              = aws_subnet.{{ $subnetResourceName }}.id
           vpc_security_group_ids = [aws_security_group.{{ $securityGroupResourceName }}.id]
 
+        {{- if $nodepool.Details.Spot }}
+          instance_market_options {
+            market_type = "spot"
+            spot_options {
+              spot_instance_type             = "one-time"
+              instance_interruption_behavior = "terminate"
+            }
+          }
+        {{- end }}
+
           tags = {
             Name            = "{{ $node.Name }}"
             Claudie-cluster = "{{ $clusterName }}-{{ $clusterHash }}"

--- a/templates/terraformer/azure/nodepool/node.tpl
+++ b/templates/terraformer/azure/nodepool/node.tpl
@@ -35,6 +35,12 @@
           zone                  = length(local.azure_zones_{{ $resourceSuffix }}) > 0 ? element(local.azure_zones_{{ $resourceSuffix }}, parseint(regex("[0-9a-f]+$", "{{ $node.Name }}"), 16)) : null
         {{- end }}
 
+        {{- if $nodepool.Details.Spot }}
+          priority        = "Spot"
+          eviction_policy = "Delete"
+          max_bid_price   = -1
+        {{- end }}
+
           source_image_reference {
             publisher = split(":", "{{ $nodepool.Details.Image }}")[0]
             offer     = split(":", "{{ $nodepool.Details.Image }}")[1]

--- a/templates/terraformer/oci/nodepool/node.tpl
+++ b/templates/terraformer/oci/nodepool/node.tpl
@@ -37,6 +37,15 @@
            }
         {{end}}
 
+        {{- if $nodepool.Details.Spot }}
+          preemptible_instance_config {
+            preemption_action {
+              type                 = "TERMINATE"
+              preserve_boot_volume = false
+            }
+          }
+        {{- end }}
+
           create_vnic_details {
             assign_public_ip  = true
             subnet_id         = oci_core_subnet.{{ $coreSubnetResourceName }}.id


### PR DESCRIPTION
Adds the spot/preemptible block to the AWS, Azure and OCI nodepool templates, gated on the nodepool spot flag:

- AWS: instance_market_options with market_type = spot
- Azure: priority = Spot, eviction_policy = Delete, max_bid_price = -1
- OCI: preemptible_instance_config

Mirrors the existing GCP and Verda spot handling. Needs a claudie version that allows these provider types in spot validation.

---
Related PRs:
- berops/claudie#2151 — allows the new provider types in spot validation; ships together with this one.
- berops/claudie-autoscaler#3 — Azure scale-from-zero arch fix (branch `fix/azure-arch-resolve-latest`); independent of this feature.
