### PR TITLE
Set cloudrift VM name and fix null port_mappings

### DIFF
--- a/templates/terraformer/cloudrift/nodepool/node.tpl
+++ b/templates/terraformer/cloudrift/nodepool/node.tpl
@@ -25,6 +25,7 @@
 
         resource "cloudrift_virtual_machine" "{{ $serverResourceName }}" {
           provider      = cloudrift.nodepool_{{ $resourceSuffix }}
+          name          = "{{ $node.Name }}"
           recipe        = "{{ $nodepool.Details.Image }}"
           datacenter    = "{{ $nodepool.Details.Region }}"
           instance_type = "{{ $nodepool.Details.ServerType }}"

--- a/templates/terraformer/cloudrift/nodepool/node.tpl
+++ b/templates/terraformer/cloudrift/nodepool/node.tpl
@@ -101,10 +101,11 @@ output "{{ $nodepool.Name }}_{{ $specName }}_{{ $uniqueFingerPrint }}" {
   value = {
     {{- range $node := $nodepool.Nodes }}
         {{- $serverResourceName := printf "%s_%s" $node.Name $resourceSuffix }}
+        {{- $portMappings := printf "cloudrift_virtual_machine.%s.port_mappings" $serverResourceName }}
         "{{ $node.Name }}" = [
           cloudrift_virtual_machine.{{ $serverResourceName }}.public_ip,
-          tostring(coalesce(one([for m in try(cloudrift_virtual_machine.{{ $serverResourceName }}.port_mappings, []) : m.guest_port if m.host_port == local.claudie_ssh_port_{{ $resourceSuffix }}]), local.claudie_ssh_port_{{ $resourceSuffix }})),
-          tostring(coalesce(one([for m in try(cloudrift_virtual_machine.{{ $serverResourceName }}.port_mappings, []) : m.guest_port if m.host_port == 51820]), 51820)),
+          tostring(coalesce(one([for m in ({{ $portMappings }} == null ? [] : {{ $portMappings }}) : m.guest_port if m.host_port == local.claudie_ssh_port_{{ $resourceSuffix }}]), local.claudie_ssh_port_{{ $resourceSuffix }})),
+          tostring(coalesce(one([for m in ({{ $portMappings }} == null ? [] : {{ $portMappings }}) : m.guest_port if m.host_port == 51820]), 51820)),
         ]
     {{- end }}
   }


### PR DESCRIPTION
Sets the `name` field on `cloudrift_virtual_machine` to the node name, so CloudRift VMs show up named `clustername-hash-nodepool-index` in the dashboard like the other providers. Uses the optional `name` attribute added in terraform-provider-cloudrift v0.2.5.

Also fixes a crash on dedicated-IP nodes: there `port_mappings` is null, and the output's `for` loop iterated over it. Guarded with a null check.