### PR TITLE
Update alternative names output generation

### DIFF
--- a/templates/terraformer/aws/dns/dns_alternative_names.tpl
+++ b/templates/terraformer/aws/dns/dns_alternative_names.tpl
@@ -6,7 +6,11 @@
 
 {{- if hasExtension .Data "AlternativeNamesExtension" }}
 	{{- range $_, $alternativeName := .Data.AlternativeNamesExtension.Names }}
-    resource "aws_route53_record" "record_{{ $alternativeName }}_{{ $resourceSuffix }}" {
+
+    {{- $escapedAlternativeName := sanitizeStringForResourceName $alternativeName }}
+    {{- $recordResourceName     := printf "record_%s_%s" $escapedAlternativeName $resourceSuffix }}
+
+    resource "aws_route53_record" "{{ $recordResourceName }}" {
       provider    = aws.dns_aws_{{ $resourceSuffix }}
       zone_id     = "${data.aws_route53_zone.aws_zone_{{ $resourceSuffix }}.zone_id }"
       name        = "{{ $alternativeName }}"
@@ -20,8 +24,8 @@
       }
     }
 
-	output "{{ $clusterID }}_{{ $alternativeName }}_{{ $resourceSuffix }}" {
-	  value = { "{{ $clusterID }}-{{ $alternativeName }}-endpoint" = aws_route53_record.record_{{ $alternativeName }}_{{ $resourceSuffix }}.name }
+	output "{{ $clusterID }}_{{ $escapedAlternativeName }}_{{ $resourceSuffix }}" {
+	  value = { "{{ $clusterID }}-{{ $alternativeName }}-endpoint" = aws_route53_record.{{ $recordResourceName }}.fqdn }
 	}
 
 	{{- end }}

--- a/templates/terraformer/azure/dns/dns_alternative_names.tpl
+++ b/templates/terraformer/azure/dns/dns_alternative_names.tpl
@@ -8,7 +8,11 @@
 {{- if hasExtension .Data "AlternativeNamesExtension" }}
 	{{- range $_, $alternativeName := .Data.AlternativeNamesExtension.Names }}
 
-	resource "azurerm_dns_cname_record" "record_{{ $alternativeName }}_{{ $resourceSuffix }}" {
+
+    {{- $escapedAlternativeName := sanitizeStringForResourceName $alternativeName }}
+    {{- $recordResourceName     := printf "record_%s_%s" $escapedAlternativeName $resourceSuffix }}
+
+	resource "azurerm_dns_cname_record" "{{ $recordResourceName }}" {
 		provider            = azurerm.dns_azure_{{ $resourceSuffix }}
 		name                = "{{ $alternativeName }}"
 		zone_name           = data.azurerm_dns_zone.azure_zone_{{ $resourceSuffix }}.name
@@ -17,8 +21,8 @@
 		record              = azurerm_traffic_manager_profile.traffic_manager_{{ $hostname }}_{{ $resourceSuffix }}.fqdn
 	}
 
-	output "{{ $clusterID }}_{{ $alternativeName }}_{{ $resourceSuffix }}" {
-		value = { "{{ $clusterID }}-{{ $alternativeName }}-endpoint" = format("%s.%s", azurerm_dns_cname_record.record_{{ $alternativeName }}_{{ $resourceSuffix }}.name, azurerm_dns_cname_record.record_{{ $alternativeName }}_{{ $resourceSuffix }}.zone_name)}
+	output "{{ $clusterID }}_{{ $escapedAlternativeName }}_{{ $resourceSuffix }}" {
+		value = { "{{ $clusterID }}-{{ $alternativeName }}-endpoint" = trimsuffix(azurerm_dns_cname_record.{{ $recordResourceName }}.fqdn, ".")}
 	}
 
 	{{- end }}

--- a/templates/terraformer/cloudflare/dns/dns_alternative_names.tpl
+++ b/templates/terraformer/cloudflare/dns/dns_alternative_names.tpl
@@ -18,7 +18,7 @@
         ttl = 300
     }
 
-	output "{{ $clusterID }}_{{ $alternativeName }}_{{ $resourceSuffix }}" {
+	output "{{ $clusterID }}_{{ $escapedAlternativeName }}_{{ $resourceSuffix }}" {
 	  value = { "{{ $clusterID }}-{{ $alternativeName }}-endpoint" = format("%s.%s", "{{ $alternativeName }}", "{{ $.Data.DNSZone }}")}
 	}
 	{{- end }}

--- a/templates/terraformer/cloudflare/dns/dns_alternative_names.tpl
+++ b/templates/terraformer/cloudflare/dns/dns_alternative_names.tpl
@@ -19,7 +19,7 @@
     }
 
 	output "{{ $clusterID }}_{{ $escapedAlternativeName }}_{{ $resourceSuffix }}" {
-	  value = { "{{ $clusterID }}-{{ $alternativeName }}-endpoint" = format("%s.%s", "{{ $alternativeName }}", "{{ $.Data.DNSZone }}")}
+	  value = { "{{ $clusterID }}-{{ $alternativeName }}-endpoint" = cloudflare_record.{{ $recordResourceName }}.hostname
 	}
 	{{- end }}
 {{- end }}

--- a/templates/terraformer/cloudflare/dns/dns_alternative_names.tpl
+++ b/templates/terraformer/cloudflare/dns/dns_alternative_names.tpl
@@ -6,8 +6,8 @@
 {{- if hasExtension .Data "AlternativeNamesExtension" }}
 	{{- range $_, $alternativeName := .Data.AlternativeNamesExtension.Names }}
 
-    {{- $escapedAlternativeName := replaceAll $alternativeName "." "_"}}
-    {{- $recordResourceName := printf "record_%s_%s" $escapedAlternativeName $resourceSuffix }}
+    {{- $escapedAlternativeName := SanitizeStringForResourceName $alternativeName }}
+    {{- $recordResourceName     := printf "record_%s_%s" $escapedAlternativeName $resourceSuffix }}
 
     resource "cloudflare_record" "{{ $recordResourceName }}" {
         provider = cloudflare.cloudflare_dns_{{ $resourceSuffix }}

--- a/templates/terraformer/cloudflare/dns/dns_alternative_names.tpl
+++ b/templates/terraformer/cloudflare/dns/dns_alternative_names.tpl
@@ -19,7 +19,7 @@
     }
 
 	output "{{ $clusterID }}_{{ $escapedAlternativeName }}_{{ $resourceSuffix }}" {
-	  value = { "{{ $clusterID }}-{{ $alternativeName }}-endpoint" = cloudflare_record.{{ $recordResourceName }}.hostname
+	  value = { "{{ $clusterID }}-{{ $alternativeName }}-endpoint" = cloudflare_record.{{ $recordResourceName }}.hostname }
 	}
 	{{- end }}
 {{- end }}

--- a/templates/terraformer/cloudflare/dns/dns_alternative_names.tpl
+++ b/templates/terraformer/cloudflare/dns/dns_alternative_names.tpl
@@ -5,7 +5,9 @@
 
 {{- if hasExtension .Data "AlternativeNamesExtension" }}
 	{{- range $_, $alternativeName := .Data.AlternativeNamesExtension.Names }}
-    {{- $recordResourceName := printf "record_%s_%s" $alternativeName $resourceSuffix }}
+
+    {{- $escapedAlternativeName := replaceAll $alternativeName "." "_"}}
+    {{- $recordResourceName := printf "record_%s_%s" $escapedAlternativeName $resourceSuffix }}
 
     resource "cloudflare_record" "{{ $recordResourceName }}" {
         provider = cloudflare.cloudflare_dns_{{ $resourceSuffix }}

--- a/templates/terraformer/cloudflare/dns/dns_alternative_names.tpl
+++ b/templates/terraformer/cloudflare/dns/dns_alternative_names.tpl
@@ -6,7 +6,7 @@
 {{- if hasExtension .Data "AlternativeNamesExtension" }}
 	{{- range $_, $alternativeName := .Data.AlternativeNamesExtension.Names }}
 
-    {{- $escapedAlternativeName := SanitizeStringForResourceName $alternativeName }}
+    {{- $escapedAlternativeName := sanitizeStringForResourceName $alternativeName }}
     {{- $recordResourceName     := printf "record_%s_%s" $escapedAlternativeName $resourceSuffix }}
 
     resource "cloudflare_record" "{{ $recordResourceName }}" {

--- a/templates/terraformer/exoscale/dns/dns_alternative_names.tpl
+++ b/templates/terraformer/exoscale/dns/dns_alternative_names.tpl
@@ -5,7 +5,9 @@
 
 {{- if hasExtension .Data "AlternativeNamesExtension" }}
 	{{- range $_, $alternativeName := .Data.AlternativeNamesExtension.Names }}
-    {{- $recordResourceName := printf "record_%s_%s" $alternativeName $resourceSuffix }}
+
+    {{- $escapedAlternativeName := sanitizeStringForResourceName $alternativeName }}
+    {{- $recordResourceName     := printf "record_%s_%s" $escapedAlternativeName $resourceSuffix }}
 
     resource "exoscale_domain_record" "{{ $recordResourceName }}" {
         provider    = exoscale.dns_{{ $resourceSuffix }}
@@ -16,8 +18,8 @@
         ttl         = 300
     }
 
-	output "{{ $clusterID }}_{{ $alternativeName }}_{{ $resourceSuffix }}" {
-	  value = { "{{ $clusterID }}-{{ $alternativeName }}-endpoint" = format("%s.%s", "{{ $alternativeName }}", "{{ $.Data.DNSZone }}")}
+	output "{{ $clusterID }}_{{ $escapedAlternativeName }}_{{ $resourceSuffix }}" {
+	  value = { "{{ $clusterID }}-{{ $alternativeName }}-endpoint" = exoscale_domain_record.{{ $recordResourceName }}.hostname }
 	}
 
 	{{- end }}

--- a/templates/terraformer/gcp/dns/dns_alternative_names.tpl
+++ b/templates/terraformer/gcp/dns/dns_alternative_names.tpl
@@ -7,7 +7,10 @@
 {{- if hasExtension .Data "AlternativeNamesExtension" }}
 	{{- range $_, $alternativeName := .Data.AlternativeNamesExtension.Names }}
 
-	resource "google_dns_record_set" "record_{{ $alternativeName }}_{{ $resourceSuffix }}" {
+    {{- $escapedAlternativeName := sanitizeStringForResourceName $alternativeName }}
+    {{- $recordResourceName     := printf "record_%s_%s" $escapedAlternativeName $resourceSuffix }}
+
+	resource "google_dns_record_set" "{{ $recordResourceName }}" {
 	  provider = google.dns_gcp_{{ $resourceSuffix }}
 
 	  name = "{{ $alternativeName }}.${data.google_dns_managed_zone.gcp_zone_{{ $resourceSuffix }}.dns_name}"
@@ -18,8 +21,8 @@
 	  rrdatas = ["{{ $hostname }}.${data.google_dns_managed_zone.gcp_zone_{{ $resourceSuffix }}.dns_name}"]
 	}
 
-	output "{{ $clusterID }}_{{ $alternativeName }}_{{ $resourceSuffix }}" {
-	  value = { "{{ $clusterID }}-{{ $alternativeName }}-endpoint" = google_dns_record_set.record_{{ $alternativeName }}_{{ $resourceSuffix }}.name }
+	output "{{ $clusterID }}_{{ $escapedAlternativeName }}_{{ $resourceSuffix }}" {
+	  value = { "{{ $clusterID }}-{{ $alternativeName }}-endpoint" = trimsuffix(google_dns_record_set.{{ $recordResourceName }}.name, ".") }
 	}
 	{{- end }}
 {{- end }}

--- a/templates/terraformer/hetzner/dns/dns_alternative_names.tpl
+++ b/templates/terraformer/hetzner/dns/dns_alternative_names.tpl
@@ -22,7 +22,7 @@
     }
 
 	output "{{ $clusterID }}_{{ $escapedAlternativeName }}_{{ $resourceSuffix }}" {
-	  value = { "{{ $clusterID }}-{{ $alternativeName }}-endpoint" = trimprefix(format("%s.%s", "{{ $alternativeName }}", "{{ $.Data.DNSZone }}"), "@.")}
+	  value = { "{{ $clusterID }}-{{ $alternativeName }}-endpoint" = format("%s.%s", "{{ $alternativeName }}", "{{ $.Data.DNSZone }}") }
 	}
 
 	{{- end }}

--- a/templates/terraformer/hetzner/dns/dns_alternative_names.tpl
+++ b/templates/terraformer/hetzner/dns/dns_alternative_names.tpl
@@ -5,7 +5,9 @@
 
 {{- if hasExtension .Data "AlternativeNamesExtension" }}
 	{{- range $_, $alternativeName := .Data.AlternativeNamesExtension.Names }}
-    {{- $recordResourceName := printf "record_%s_%s" $alternativeName $resourceSuffix }}
+
+    {{- $escapedAlternativeName := sanitizeStringForResourceName $alternativeName }}
+    {{- $recordResourceName     := printf "record_%s_%s" $escapedAlternativeName $resourceSuffix }}
 
     resource "hcloud_zone_rrset" "{{ $recordResourceName }}" {
         provider = hcloud.hetzner_dns_{{ $resourceSuffix }}
@@ -19,8 +21,8 @@
         ]
     }
 
-	output "{{ $clusterID }}_{{ $alternativeName }}_{{ $resourceSuffix }}" {
-	  value = { "{{ $clusterID }}-{{ $alternativeName }}-endpoint" = format("%s.%s", "{{ $alternativeName }}", "{{ $.Data.DNSZone }}")}
+	output "{{ $clusterID }}_{{ $escapedAlternativeName }}_{{ $resourceSuffix }}" {
+	  value = { "{{ $clusterID }}-{{ $alternativeName }}-endpoint" = trimprefix(format("%s.%s", "{{ $alternativeName }}", "{{ $.Data.DNSZone }}"), "@.")}
 	}
 
 	{{- end }}

--- a/templates/terraformer/oci/dns/dns_alternative_names.tpl
+++ b/templates/terraformer/oci/dns/dns_alternative_names.tpl
@@ -7,7 +7,10 @@
 {{- if hasExtension .Data "AlternativeNamesExtension" }}
 	{{- range $_, $alternativeName := .Data.AlternativeNamesExtension.Names }}
 
-	resource "oci_dns_rrset" "record_{{ $alternativeName }}_{{ $resourceSuffix }}" {
+    {{- $escapedAlternativeName := sanitizeStringForResourceName $alternativeName }}
+    {{- $recordResourceName     := printf "record_%s_%s" $escapedAlternativeName $resourceSuffix }}
+
+	resource "oci_dns_rrset" "{{ $recordResourceName }}" {
 		provider        = oci.dns_oci_{{ $resourceSuffix }}
 		domain          = "{{ $alternativeName }}.${data.oci_dns_zones.oci_zone_{{ $resourceSuffix }}.name}"
 		rtype           = "CNAME"
@@ -20,8 +23,8 @@
 			rdata  = "{{ $hostname }}.${data.oci_dns_zones.oci_zone_{{ $resourceSuffix }}.name}"
   		}
 	}
-	output "{{ $clusterID }}_{{ $alternativeName }}_{{ $resourceSuffix }}" {
-	  value = { "{{ $clusterID }}-{{ $alternativeName }}-endpoint" = oci_dns_rrset.record_{{ $alternativeName }}_{{ $resourceSuffix }}.domain }
+	output "{{ $clusterID }}_{{ $escapedAlternativeName }}_{{ $resourceSuffix }}" {
+	  value = { "{{ $clusterID }}-{{ $alternativeName }}-endpoint" = oci_dns_rrset.{{ $recordResourceName }}.domain }
 	}
 	{{- end }}
 {{- end }}

--- a/templates/terraformer/ovh/dns/dns_alternative_names.tpl
+++ b/templates/terraformer/ovh/dns/dns_alternative_names.tpl
@@ -5,7 +5,9 @@
 
 {{- if hasExtension .Data "AlternativeNamesExtension" }}
 	{{- range $_, $alternativeName := .Data.AlternativeNamesExtension.Names }}
-    {{- $recordResourceName := printf "record_%s_%s" $alternativeName $resourceSuffix }}
+
+    {{- $escapedAlternativeName := sanitizeStringForResourceName $alternativeName }}
+    {{- $recordResourceName     := printf "record_%s_%s" $escapedAlternativeName $resourceSuffix }}
 
     resource "ovh_domain_zone_record" "{{ $recordResourceName }}" {
         provider  = ovh.dns_{{ $resourceSuffix }}
@@ -16,7 +18,7 @@
         ttl       = 60
     }
 
-	output "{{ $clusterID }}_{{ $alternativeName }}_{{ $resourceSuffix }}" {
+	output "{{ $clusterID }}_{{ $escapedAlternativeName }}_{{ $resourceSuffix }}" {
 	  value = { "{{ $clusterID }}-{{ $alternativeName }}-endpoint" = format("%s.%s", "{{ $alternativeName }}", "{{ $.Data.DNSZone }}")}
 	}
 


### PR DESCRIPTION
Updates alternative names output generation so that hostnames such as "@" or "x.y.z" work


After merging this, the alternative names will only work with the changes from the next upcoming claudie release, thus won't be backwards compatible with older claudie versions

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved DNS template generation across multiple cloud providers by using safe, sanitized names in resource and output identifiers.
  * Reduced the risk of invalid Terraform names when alternative DNS names contain special characters.
  * Updated generated DNS outputs to reference the created record values more consistently.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->